### PR TITLE
fermisurface/spectrum/ldos/kdos: parallelize 8 more pcall sites with numba prange

### DIFF
--- a/src/pyqula/fermisurfacetk/singlefs.py
+++ b/src/pyqula/fermisurfacetk/singlefs.py
@@ -93,7 +93,20 @@ def fermi_surface(h,write=True,output_file="FERMI_MAP.OUT",
     rs = np.array(rs) # transform into array
     kxout = rs[:,0] # x coordinate
     kyout = rs[:,1] # y coordinate
-    if parallel.cores==1: # serial execution
+    if mode=='eigen' and operator is None:
+        # batched, numba-parallel path -- no interprocess dispatch
+        from ..htk.eigenvectors import peigvalsh
+        ks = np.array([R(r)+k0 for r in rs]) # kpoints, change of basis applied
+        kdos = np.zeros(len(rs),dtype=np.float64)
+        batch_size = 64
+        for i0 in range(0,len(rs),batch_size): # loop over batches of kpoints
+            kbatch = ks[i0:i0+batch_size]
+            mats = np.array([hk_gen(k) for k in kbatch],dtype=np.complex128)
+            es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
+            for ii in range(len(kbatch)):
+                es = es_batch[ii]
+                kdos[i0+ii] = np.sum(delta/((e-es)**2+delta**2))
+    elif parallel.cores==1: # serial execution
         kdos = np.zeros(len(rs),dtype=np.float64) # empty array
         for ir in range(len(rs)): # loop
             kdos[ir] = getf(rs[ir]) # store

--- a/src/pyqula/spectrum.py
+++ b/src/pyqula/spectrum.py
@@ -370,21 +370,22 @@ def get_filling(h,**kwargs):
 
 
 
-def eigenvalues_kmesh(h,nk=20):
+def eigenvalues_kmesh(h,nk=20,batch_size=64):
     """Get the eigenvalues in a kmesh"""
     if h.dimensionality!=2: raise # only for 2d
     ne = h.intra.shape[0] # number of energies per k-point
-    es = np.zeros((nk,nk,ne)) # array for the energies 
+    es = np.zeros((nk,nk,ne)) # array for the energies
     hkgen = h.get_hk_gen() # get the generator
     kx = np.linspace(0.,1.,nk,endpoint=False)
     ky = np.linspace(0.,1.,nk,endpoint=False)
-    for i in range(nk):
-      ik = kx[i] # kx point   
-      for j in range(nk):
-        jk = ky[j] # ky point
-        hk = hkgen([ik,jk]) # get the matrix
-        ei = algebra.eigvalsh(hk) # get the energies
-        es[i,j,:] = ei # store energies
+    from .htk.eigenvectors import peigvalsh
+    ijs = [(i,j) for i in range(nk) for j in range(nk)] # flat list of grid indices
+    for i0 in range(0,len(ijs),batch_size): # loop over batches of kpoints
+        ijbatch = ijs[i0:i0+batch_size]
+        mats = np.array([hkgen([kx[i],ky[j]]) for (i,j) in ijbatch],dtype=np.complex128)
+        es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
+        for ii,(i,j) in enumerate(ijbatch):
+            es[i,j,:] = es_batch[ii] # store energies
     return es # return all the energies
 
 

--- a/tests/chi/test_eigenvalues_kmesh.py
+++ b/tests/chi/test_eigenvalues_kmesh.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from pyqula import geometry, algebra
+from pyqula.spectrum import eigenvalues_kmesh
+
+
+def _serial_reference(h, nk):
+    """Verbatim pre-refactor eigenvalues_kmesh: a plain nested loop, no
+    parallelism at all."""
+    ne = h.intra.shape[0]
+    es = np.zeros((nk, nk, ne))
+    hkgen = h.get_hk_gen()
+    kx = np.linspace(0., 1., nk, endpoint=False)
+    ky = np.linspace(0., 1., nk, endpoint=False)
+    for i in range(nk):
+        for j in range(nk):
+            hk = hkgen([kx[i], ky[j]])
+            es[i, j, :] = algebra.eigvalsh(hk)
+    return es
+
+
+def test_eigenvalues_kmesh_matches_serial_reference():
+    """eigenvalues_kmesh (used by get_qpi's default "response" mode via
+    epsilonk) is now batched through numba prange; check it still agrees
+    with the plain nested-loop implementation it replaced."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    nk = 6
+    new = eigenvalues_kmesh(h, nk=nk, batch_size=5) # not a divisor of nk*nk
+    old = _serial_reference(h, nk)
+    assert new.shape == old.shape
+    assert np.allclose(np.sort(new, axis=2), np.sort(old, axis=2))
+
+
+def test_eigenvalues_kmesh_independent_of_batch_size():
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    nk = 6
+    outs = [eigenvalues_kmesh(h, nk=nk, batch_size=bs) for bs in (1, 4, 36, 100)]
+    for o in outs[1:]:
+        assert np.allclose(o, outs[0])

--- a/tests/fermisurface/test_fermi_surface.py
+++ b/tests/fermisurface/test_fermi_surface.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import algebra
+from pyqula import parallel
+from pyqula.fermisurfacetk.singlefs import fermi_surface
+
+
+def _serial_reference(h, nk, e, delta):
+    """Verbatim pre-refactor per-kpoint loop for mode='eigen', operator=None."""
+    hk_gen = h.get_hk_gen()
+    R = h.geometry.get_k2K_generator()
+    kxs = np.linspace(-1, 1, nk)
+    kys = np.linspace(-1, 1, nk)
+    out = []
+    for x in kxs:
+        for y in kys:
+            k = R(np.array([x, y, 0.]))
+            hk = hk_gen(k)
+            es = algebra.eigvalsh(hk)
+            out.append(np.sum(delta/((e-es)**2+delta**2)))
+    return np.array(out)
+
+
+def test_fermi_surface_matches_serial_reference(tmp_path, monkeypatch):
+    """h.get_fermi_surface()'s default mode ('eigen', no operator) is now
+    batched through numba prange; check it still agrees with the plain
+    per-kpoint loop it replaced."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    nk = 6
+    e, delta = 0.2, 0.1
+    kx, ky, new = fermi_surface(h, write=False, nk=nk, e=e, delta=delta)
+    old = _serial_reference(h, nk, e, delta)
+    assert new.shape == old.shape
+    assert np.allclose(new, old)
+
+
+def test_fermi_surface_independent_of_core_count(tmp_path, monkeypatch):
+    """The batched path doesn't use parallel.pcall at all; result must not
+    depend on the (now-irrelevant, for this mode) process-pool setting."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    try:
+        outs = []
+        for cores in (1, 2, 4):
+            parallel.set_cores(cores)
+            _, _, kdos = fermi_surface(h, write=False, nk=6, e=0.1, delta=0.1)
+            outs.append(kdos)
+        for o in outs[1:]:
+            assert np.allclose(o, outs[0])
+    finally:
+        parallel.set_cores(1)
+
+
+def test_fermi_surface_operator_mode_still_uses_pcall_path(tmp_path, monkeypatch):
+    """mode='eigen' with an operator falls back to the original per-kpoint
+    dispatch (h.get_dos per kpoint) -- just a smoke test that this path
+    still runs and returns the right shape."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    kx, ky, kdos = fermi_surface(h, write=False, nk=4, e=0.1, delta=0.1,
+                                  operator="sz")
+    assert kdos.shape == kx.shape


### PR DESCRIPTION
## Stacked on #21

This targets \`bands-dos-numba\` (#21's branch), so the diff here is just this branch's own changes. Once #19-21 merge, this should retarget to \`master\`.

## Summary

Two commits, eight functions total — the second commit works through items 1-6 of the [pcall inventory/roadmap](https://claude.ai/code/artifact/e3e91b81-85dd-4556-8733-d0541b0f88db) (§14 of the plan artifact), in the recommended order.

### First commit: fermi_surface and get_qpi

- **\`h.get_fermi_surface()\`** (routes through \`fermisurfacetk/singlefs.py\`'s \`fermi_surface\`) — default case (\`mode='eigen'\`, no operator) batched via \`peigvalsh\`.
- **\`get_qpi\`'s default mode (\`"response"\`)** depends on \`spectrum.eigenvalues_kmesh\`, which had **no parallelism at all**. Batched; \`get_qpi\` inherits the fix transitively.

### Second commit: six more sites from the roadmap

1. **\`filling.eigenvalues\`** — same shape as \`eigenvalues_kmesh\`, zero branching.
2. **\`htk/eigenvectors.get_eigenvectors\`**, dense branch — the eigenvector-returning sibling of \`peigvalsh\`, in the same file that defines it.
3. **\`fermisurface.fermi_surface_generator\`** — legacy sibling of \`fermisurfacetk/singlefs.py\`'s \`fermi_surface\` (above): same branching, same fix applied a second time.
4. **\`spectrum.total_energy\`** — KPM/dense/sparse/mesh-random-integrate branching, same shape as \`get_bands_nd\`. Batches the dense mesh/random case only.
5. **\`ldos.ldosmap\`** — required splitting \`ldos_waves\` into diagonalization + a new \`ldos_waves_from_eigsystem\` post-processing half, so the batched path can reuse the post-processing without re-diagonalizing.
6. **\`kdos.kdos_bands\`, mode="ED"** — not a simple swap. It previously wrapped many cheap single-kpoint \`h.get_dos\` calls in an outer process pool — the overhead-dominates-work anti-pattern this whole migration exists to fix. Bypassed \`get_dos\` entirely; now calls \`h.get_bands\` once for the whole kpath (already numba-parallel) and computes each kpoint's DOS from its own slice of the result.

## Results, measured at exactly 4 numba threads

| Size | fermi_surface | eigenvalues_kmesh | filling.eigenvalues | get_eigenvectors | fermi_surface_generator | total_energy | ldosmap | kdos_bands |
|---|---|---|---|---|---|---|---|---|
| 2 sites | 2.13x | 2.53x | 4.37x | 1.60x | 2.27x | 2.82x | 181.6x* | 2.73x |
| 50 sites | 1.42x | 1.72x | 1.06x | 3.44x | 1.22x | 2.00x | 1.65x | 3.95x |
| 200 sites | 1.34x | 1.24x | **0.98x** | 2.82x | **0.96x** | 1.92x | 2.00x | 3.38x |

*\`ldosmap\`'s 2-site number is almost certainly a warmup/call-overhead artifact (both raw times are ~1ms); the 50/200-site numbers are the trustworthy ones.

**Not smoothed over**: \`filling.eigenvalues\` and \`fermi_surface_generator\` drop to ~0.96-0.98x at the largest tested size — essentially no difference from the original loop, not a regression but not a win either. Both use \`peigvalsh\` the same way four other functions here that stayed comfortably above 1x do, so the reason isn't obvious from the code alone. Flagged as an open question rather than papered over.

## Also found (unrelated to this change)

Chasing an apparent \`ldosmap\` mismatch during testing led to discovering that importing \`jax\` (transitively, lazily) triggers \`jax/_src/clusters/k8s_cluster.py\`'s module-level \`np.random.rand(5)\` as a side effect, silently desyncing any test comparing two \`np.random.seed()\`-based code paths depending on import timing. Not a bug in this PR; the tests touching randomness now pin kpoints explicitly via a monkeypatched \`np.random.random\` instead of relying on seed reproducibility across that boundary. Also confirmed (via \`git stash\` comparison against the unmodified baseline) that a pre-existing NaN in \`total_energy\`'s KPM path for tiny systems is unrelated to this change.

## Test plan

- [x] \`python -m pytest tests\` — 51 passed, 0 regressions
- [x] All eight conversions verified against inlined serial reference implementations
- [x] Non-fast-path branches (operator-given, sparse/ARPACK, Green, KPM) smoke-tested to confirm they still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7TkHmpFfRb2tuLx8GnVT7