### PR TITLE
6 more pcall->prange conversions + serial-vs-parallel tests (missed by #22's early merge)

### DIFF
--- a/src/pyqula/fermisurface.py
+++ b/src/pyqula/fermisurface.py
@@ -81,7 +81,18 @@ def fermi_surface_generator(h,
     kxout = rs[:,0] # x coordinate
     kyout = rs[:,1] # y coordinate
     kdos = np.zeros((len(rs),len(energies))) # initialize
-    if parallel.cores==1: # serial execution
+    if mode=='full' and operator is None:
+        # batched, numba-parallel path -- no interprocess dispatch
+        from .htk.eigenvectors import peigvalsh
+        ks = np.array([fR(r) for r in rs]) # kpoints, change of basis applied
+        batch_size = 64
+        for i0 in range(0,len(rs),batch_size): # loop over batches of kpoints
+            kbatch = ks[i0:i0+batch_size]
+            mats = np.array([hk_gen(k) for k in kbatch],dtype=np.complex128)
+            es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
+            for ii in range(len(kbatch)):
+                kdos[i0+ii,:] = fermi_weight(es_batch[ii],energies,delta=delta)
+    elif parallel.cores==1: # serial execution
         for ir in range(len(rs)): # loop
           if info: print("Doing",rs[ir])
           kdos[ir,:] = getf(rs[ir]) # store in the list

--- a/src/pyqula/filling.py
+++ b/src/pyqula/filling.py
@@ -20,16 +20,20 @@ def get_fermi_energy(es,filling,fermi_shift=0.0,
 
 
 
-def eigenvalues(h0,nk=10,notime=True):
+def eigenvalues(h0,nk=10,notime=True,batch_size=64):
     """Return all the eigenvalues of a Hamiltonian"""
     from . import klist
+    from .htk.eigenvectors import peigvalsh
     h = h0.copy() # copy hamiltonian
     h = h.get_dense()
     ks = klist.kmesh(h.dimensionality,nk=nk) # get grid
     hkgen = h.get_hk_gen() # get generator
-    f = lambda k: algebra.eigvalsh(hkgen(k)) # add
-    es = parallel.pcall(f,ks) # call in parallel
-    es = np.array(es)
+    es_all = [] # list of batches
+    for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
+        kbatch = ks[i0:i0+batch_size]
+        mats = np.array([hkgen(k) for k in kbatch],dtype=np.complex128)
+        es_all.append(peigvalsh(mats)) # diagonalize the whole batch in parallel
+    es = np.concatenate(es_all,axis=0)
     es = es.reshape(es.shape[0]*es.shape[1])
     return es # return all the eigenvalues
 

--- a/src/pyqula/htk/eigenvectors.py
+++ b/src/pyqula/htk/eigenvectors.py
@@ -26,11 +26,15 @@ def get_eigenvectors(h,nk=10,kpoints=False,k=None,sparse=False,
     if sparse: # sparse Hamiltonians
         fk = lambda k: slg.eigsh(csc(f(k)),k=numw,which="LM",sigma=energy,tol=1e-5)
         vvs = parallel.pcall(fk,kp)
-    else: # dense Hamiltonians
-      if parallel.cores>1: # in parallel
-#        vvs = parallel.multieigh([f(k) for k in kp]) # multidiagonalization
-        vvs = parallel.pcall(lambda k: algebra.eigh(f(k)),kp)
-      else: vvs = [algebra.eigh(f(k)) for k in kp] # 
+    else: # dense Hamiltonians: batched, numba-parallel diagonalization,
+          # no interprocess communication
+      batch_size = 64
+      vvs = []
+      for i0 in range(0,len(kp),batch_size): # loop over batches of kpoints
+        kbatch = kp[i0:i0+batch_size]
+        mats = np.array([f(kk) for kk in kbatch],dtype=np.complex128)
+        es_batch,ws_batch = parallel_diagonalization(mats) # diagonalize the batch in parallel
+        for ii in range(len(kbatch)): vvs.append((es_batch[ii],ws_batch[ii]))
     nume = sum([len(v[0]) for v in vvs]) # number of eigenvalues calculated
     eigvecs = np.zeros((nume,h.intra.shape[0]),dtype=np.complex128) # eigenvectors
     eigvals = np.zeros(nume) # eigenvalues

--- a/src/pyqula/kdos.py
+++ b/src/pyqula/kdos.py
@@ -156,12 +156,29 @@ def kdos_bands(h,use_kpm=False,kpath=None,scale=10.0,frand=None,
                  mode="ED",**kwargs):
     """Calculate the KDOS bands using the KPM"""
     if use_kpm: mode ="KPM" # conventional method
+    if kpath is None:
+        kpath = h.geometry.get_kpath(kpath,nk=nk) # generate kpath
     if mode=="ED":
-        from . import dos
-        def pfun(k):
-          (es,ds) = h.get_dos(ks=[k],operator=operator,energies=energies,
-                  delta=delta,**kwargs)
-          return energies,ds
+        # batched path: diagonalize the whole kpath at once via get_bands
+        # (already numba-parallel, see bandstructure.get_bands_nd) instead
+        # of dispatching one h.get_dos call per kpoint through an outer
+        # process pool -- that wrapped many cheap single-kpoint
+        # diagonalizations in pcall, exactly the overhead-dominates-work
+        # failure mode the rest of this codebase's pcall->prange migration
+        # was built to avoid.
+        from .dostk.eigtodos import calculate_dos
+        bout = h.get_bands(kpath=kpath,operator=operator,write=False,**kwargs)
+        kidx = bout[0].astype(int) # k-index per row
+        es_col = bout[1] # energy per row
+        w_col = bout[2] if len(bout)>2 else None # operator weight per row, if any
+        out = [] # (energies,dos) pair per kpoint, matching the old pfun contract
+        for ik in range(len(kpath)):
+            mask = kidx==ik
+            es_k = es_col[mask]
+            w_k = w_col[mask] if w_col is not None else None
+            ys = calculate_dos(es_k,energies,delta,w=w_k)
+            ys *= 1./np.pi
+            out.append((energies,ys))
     elif mode=="green":
       f = h.get_gk_gen(delta=delta) # Green generator
       def pfun(k): # do it for this k-point
@@ -170,6 +187,7 @@ def kdos_bands(h,use_kpm=False,kpath=None,scale=10.0,frand=None,
               m = green.GtimesO(m,operator,k=k)
               return -algebra.trace(m).imag # return DOS
           return energies,np.array([gfun(e) for e in energies])
+      out = parallel.pcall(pfun,kpath) # compute all
     elif mode=="KPM": # KPM method
       if operator is not None: 
           from .operators import Operator
@@ -186,11 +204,9 @@ def kdos_bands(h,use_kpm=False,kpath=None,scale=10.0,frand=None,
                      ewindow=ewindow,ntries=ntries,x=energies,
                      **kwargs) # compute
         return (x,y)
-    if kpath is None:
-        kpath = h.geometry.get_kpath(kpath,nk=nk) # generate kpath
+      out = parallel.pcall(pfun,kpath) # compute all
     ### Now compute and write in a file
     ik = 0
-    out = parallel.pcall(pfun,kpath) # compute all
     fo = open("KDOS_BANDS.OUT","w") # open file
     for k in kpath: # loop over kpoints
       (x,y) = out[ik] # get this one

--- a/src/pyqula/ldos.py
+++ b/src/pyqula/ldos.py
@@ -158,10 +158,26 @@ def ldosmap(h,energies=np.linspace(-1.0,1.0,40),delta=None,
   def getd(k): # get LDOS
     hk = hkgen(k) # get Hamiltonian
     # LDOS for this kpoint
-    ds = ldos_waves(hk,k=k,es=energies,delta=delta,operator=operator,**kwargs) 
+    ds = ldos_waves(hk,k=k,es=energies,delta=delta,operator=operator,**kwargs)
     return ds
   ks = [np.random.random(3) for ik in range(nk)] # kpoints
-  ds = parallel.pcall(getd,ks) # get densities
+  if kwargs.get("num_bands") is None and not kwargs.get("non_hermitian",False):
+      # batched, numba-parallel path -- no interprocess dispatch
+      from .htk.eigenvectors import parallel_diagonalization
+      from .ldostk.ldoswaves import ldos_waves_from_eigsystem
+      delta_discard = kwargs.get("delta_discard")
+      ds = []
+      batch_size = 64
+      for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
+          kbatch = ks[i0:i0+batch_size]
+          mats = np.array([hkgen(k) for k in kbatch],dtype=np.complex128)
+          es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize the batch in parallel
+          for ii,k in enumerate(kbatch):
+              eigvec = vs_batch[ii].T # rows are eigenvectors
+              ds.append(ldos_waves_from_eigsystem(es_batch[ii],eigvec,energies,
+                      delta,operator=operator,k=k,delta_discard=delta_discard))
+  else:
+      ds = parallel.pcall(getd,ks) # get densities
   dstot = np.mean(ds,axis=0) # average over first axis
   print("LDOS finished")
   dstot = [spatial_dos(h,d) for d in dstot] # convert to spatial resolved DOS

--- a/src/pyqula/ldostk/ldoswaves.py
+++ b/src/pyqula/ldostk/ldoswaves.py
@@ -14,9 +14,18 @@ def ldos_diagonalization(m,e=0.0,**kwargs):
 def ldos_waves(intra,es = [0.0],delta=0.01,operator=None,
         k=None,delta_discard=None,**kwargs):
   """Calculate the DOS in a set of energies by full diagonalization"""
-  es = np.array(es) # array with energies
   emean = np.mean(es) # average energy
   eig,eigvec = get_waves(intra,e0=emean,**kwargs) # eigenvalues and eigenvectors
+  return ldos_waves_from_eigsystem(eig,eigvec,es,delta,operator=operator,
+          k=k,delta_discard=delta_discard)
+
+
+def ldos_waves_from_eigsystem(eig,eigvec,es,delta,operator=None,
+        k=None,delta_discard=None):
+  """Same as ldos_waves, but starting from an already-diagonalized
+  (eig, eigvec) pair instead of diagonalizing internally -- lets callers
+  batch the diagonalization step themselves (see fermisurface.ldosmap)."""
+  es = np.array(es) # array with energies
   ds = [] # empty list
   if operator is None: weights = eig.real*0. + 1.0 # initialize as 1
   else: weights = [operator.braket(v,k=k) for v in eigvec] # weights
@@ -26,7 +35,7 @@ def ldos_waves(intra,es = [0.0],delta=0.01,operator=None,
           e = eig[i]
           if not ewin[0]<e<ewin[1]: weights[i] = 0.0
   v2s = [(np.conjugate(v)*v).real for v in eigvec] # square of the wavefunction
-  ds = [[0.0 for i in range(intra.shape[0])] for e in es] # initialize
+  ds = [[0.0 for i in range(eigvec.shape[1])] for e in es] # initialize
   ds = ldos_waves_jit(np.array(es),
           np.array(eigvec).T,np.array(eig),np.array(weights),
           np.array(v2s),np.array(ds),delta)

--- a/src/pyqula/spectrum.py
+++ b/src/pyqula/spectrum.py
@@ -244,7 +244,23 @@ def total_energy(h,nk=10,nbands=None,use_kpm=False,random=False,
           vv = vv[0:nbands] # get the negative eigenvlaues closest to EF
       return np.sum(vv[vv<fermi]) # sum energies below fermi energy
   # compute energy using different modes
-  if mode=="mesh":
+  if mode in ("mesh","random") and (not use_kpm) and nbands is None:
+    # batched, numba-parallel path -- no interprocess dispatch
+    from .htk.eigenvectors import peigvalsh
+    if mode=="mesh":
+        from .klist import kmesh
+        kp = kmesh(h.dimensionality,nk=nk)
+    else: # random
+        kp = [np.random.random(3) for i in range(nk)]
+    sums = [] # per-kpoint sum of energies below the fermi energy
+    batch_size = 64
+    for i0 in range(0,len(kp),batch_size): # loop over batches of kpoints
+        kbatch = kp[i0:i0+batch_size]
+        mats = np.array([f(k) for k in kbatch],dtype=np.complex128)
+        es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
+        for es in es_batch: sums.append(np.sum(es[es<fermi]))
+    etot = np.mean(sums) # compute total energy
+  elif mode=="mesh":
     from .klist import kmesh
     kp = kmesh(h.dimensionality,nk=nk)
     etot = np.mean(parallel.pcall(enek,kp)) # compute total energy

--- a/tests/fermisurface/test_fermi_surface_generator.py
+++ b/tests/fermisurface/test_fermi_surface_generator.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from pyqula import geometry, algebra
+from pyqula.fermisurface import fermi_surface_generator, fermi_weight
+
+
+def _serial_reference(h, nk, energies, delta):
+    hk_gen = h.get_hk_gen()
+    kxs = np.linspace(-1, 1, nk, endpoint=True)
+    kys = np.linspace(-1, 1, nk, endpoint=True)
+    fR = h.geometry.get_k2K_generator()
+    from pyqula.klist import kgrid2d
+    rs = np.array(kgrid2d(kxs, kys))
+    out = []
+    for r in rs:
+        hk = hk_gen(fR(r))
+        es = algebra.eigvalsh(hk)
+        out.append(fermi_weight(es, np.array(energies), delta=delta))
+    return rs, np.array(out)
+
+
+def test_fermi_surface_generator_matches_serial_reference():
+    """fermi_surface_generator's default (dense, no operator) case is now
+    batched through numba prange; check it still agrees with the plain
+    per-kpoint loop it replaced. This is the multi-energy sibling of
+    fermisurfacetk.singlefs.fermi_surface (already converted separately)."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    energies = [0.0, 0.2]
+    delta = 0.1
+    _, rs_new, kdos_new = fermi_surface_generator(h, energies=energies, nk=5, delta=delta)
+    rs_old, kdos_old = _serial_reference(h, 5, energies, delta)
+    assert np.allclose(rs_new, rs_old)
+    assert np.allclose(kdos_new, kdos_old)
+
+
+def test_fermi_surface_generator_operator_mode_still_works():
+    """Operator-given case falls back to the original pcall path -- smoke
+    test it still runs and returns the right shape."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    _, rs, kdos = fermi_surface_generator(h, energies=[0.0], nk=4, delta=0.1,
+                                            operator="sz")
+    assert kdos.shape == (len(rs), 1)

--- a/tests/kdos/test_kdos_bands.py
+++ b/tests/kdos/test_kdos_bands.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.kdos import kdos_bands
+
+
+def _serial_reference(h, kpath, energies, delta, operator=None):
+    """Verbatim pre-refactor per-kpoint loop for mode='ED': one
+    h.get_dos(ks=[k], ...) call per kpoint."""
+    out = []
+    for k in kpath:
+        (es, ds) = h.get_dos(ks=[k], operator=operator, energies=energies, delta=delta)
+        out.append((es, ds))
+    return out
+
+
+def test_kdos_bands_ed_matches_serial_reference(tmp_path, monkeypatch):
+    """kdos_bands' default (mode='ED') case now diagonalizes the whole
+    kpath at once via h.get_bands instead of dispatching one h.get_dos
+    call per kpoint through pcall; check it still agrees."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    kpath = h.geometry.get_kpath(None, nk=8)
+    energies = np.linspace(-3, 3, 50)
+    delta = 0.1
+
+    new = kdos_bands(h, kpath=kpath, energies=energies, delta=delta, mode="ED")
+    old = _serial_reference(h, kpath, energies, delta)
+    old_y = np.concatenate([o[1] for o in old])
+    assert np.allclose(new[2], old_y)
+
+
+def test_kdos_bands_ed_with_operator_matches_serial_reference(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    kpath = h.geometry.get_kpath(None, nk=6)
+    energies = np.linspace(-3, 3, 30)
+    delta = 0.1
+
+    new = kdos_bands(h, kpath=kpath, energies=energies, delta=delta,
+                      mode="ED", operator="sz")
+    old = _serial_reference(h, kpath, energies, delta, operator="sz")
+    old_y = np.concatenate([o[1] for o in old])
+    assert np.allclose(new[2], old_y)
+
+
+def test_kdos_bands_green_and_kpm_modes_still_work(tmp_path, monkeypatch):
+    """Smoke test: green and KPM modes keep their original pcall path and
+    shouldn't be affected by the ED-mode change."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    kpath = h.geometry.get_kpath(None, nk=4)
+    energies = np.linspace(-3, 3, 20)
+
+    out_green = kdos_bands(h, kpath=kpath, energies=energies, delta=0.1, mode="green")
+    assert np.all(np.isfinite(out_green[2]))
+
+    out_kpm = kdos_bands(h, kpath=kpath, energies=energies, delta=0.1,
+                          mode="KPM", scale=5.0, ntries=2)
+    assert np.all(np.isfinite(out_kpm[2]))

--- a/tests/ldos/test_ldosmap.py
+++ b/tests/ldos/test_ldosmap.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.ldos import ldosmap
+from pyqula.ldostk.ldoswaves import ldos_waves
+
+
+def _fixed_random_random(monkeypatch, ks):
+    """Replace np.random.random with a stand-in that returns the given
+    kpoints in order, one per call -- used so ldosmap's internal call and
+    a hand-written serial reference are guaranteed to see the identical
+    kpoints, independent of whatever else in the process (e.g. a
+    module's own import-time use of the global numpy RNG) may have
+    touched np.random's state first."""
+    it = iter(ks)
+    monkeypatch.setattr(np.random, "random", lambda *a, **kw: next(it))
+
+
+def test_ldosmap_matches_serial_reference(monkeypatch):
+    """ldosmap's default (dense, Hermitian) case is now batched through
+    numba prange; check it still agrees with the plain per-kpoint
+    ldos_waves loop it replaced, given the same kpoints."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    energies = np.linspace(-1, 1, 10)
+    delta = 0.1
+    nk = 6
+    rng = np.random.RandomState(0)
+    ks = [rng.random(3) for _ in range(nk)]
+
+    _fixed_random_random(monkeypatch, ks)
+    _, new = ldosmap(h, energies=energies, delta=delta, nk=nk)
+
+    hkgen = h.get_hk_gen()
+    ds = [ldos_waves(hkgen(k), k=k, es=energies, delta=delta, operator=None) for k in ks]
+    dstot = np.mean(ds, axis=0)
+    from pyqula.ldos import spatial_dos
+    old = np.array([spatial_dos(h, d) for d in dstot])
+
+    assert np.allclose(new, old)

--- a/tests/parallel/test_filling_eigenvalues.py
+++ b/tests/parallel/test_filling_eigenvalues.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from pyqula import geometry, algebra
+from pyqula import klist
+from pyqula.filling import eigenvalues
+
+
+def _serial_reference(h0, nk):
+    h = h0.copy(); h = h.get_dense()
+    ks = klist.kmesh(h.dimensionality, nk=nk)
+    hkgen = h.get_hk_gen()
+    es = np.array([algebra.eigvalsh(hkgen(k)) for k in ks])
+    return es.reshape(es.shape[0] * es.shape[1])
+
+
+def test_filling_eigenvalues_matches_serial_reference():
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    new = eigenvalues(h, nk=6, batch_size=5) # not a divisor of nk^2
+    old = _serial_reference(h, nk=6)
+    assert np.allclose(np.sort(new), np.sort(old))
+
+
+def test_filling_eigenvalues_independent_of_batch_size():
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    outs = [eigenvalues(h, nk=6, batch_size=bs) for bs in (1, 5, 36, 100)]
+    for o in outs[1:]:
+        assert np.allclose(np.sort(o), np.sort(outs[0]))

--- a/tests/parallel/test_get_eigenvectors_dense.py
+++ b/tests/parallel/test_get_eigenvectors_dense.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from pyqula import geometry, algebra
+from pyqula.htk.eigenvectors import get_eigenvectors
+
+
+def _serial_reference(h, nk):
+    from pyqula.klist import kmesh
+    f = h.get_hk_gen()
+    kp = kmesh(h.dimensionality, nk=nk)
+    vvs = [algebra.eigh(f(k)) for k in kp]
+    nume = sum(len(v[0]) for v in vvs)
+    eigvecs = np.zeros((nume, h.intra.shape[0]), dtype=np.complex128)
+    eigvals = np.zeros(nume)
+    iv = 0
+    for ik in range(len(kp)):
+        vv = vvs[ik]
+        for (e, v) in zip(vv[0], vv[1].transpose()):
+            eigvecs[iv] = v.copy(); eigvals[iv] = e.copy(); iv += 1
+    return eigvals, eigvecs
+
+
+def test_get_eigenvectors_dense_matches_serial_reference():
+    """get_eigenvectors' dense branch is now batched through numba prange
+    (parallel_diagonalization); eigenvalues must match exactly, and the
+    span of eigenvectors per kpoint-block must match up to the ordinary
+    phase ambiguity between independent diagonalizations of the same
+    matrix -- checked via the phase-invariant density-matrix sum rather
+    than direct array equality."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    new_es, new_vs = get_eigenvectors(h, nk=5)
+    old_es, old_vs = _serial_reference(h, nk=5)
+    assert np.allclose(np.sort(new_es), np.sort(old_es))
+    dm_new = np.conj(new_vs).T @ new_vs
+    dm_old = np.conj(old_vs).T @ old_vs
+    assert np.allclose(dm_new, dm_old, atol=1e-8)
+
+
+def test_get_eigenvectors_single_kpoint_still_works():
+    """k=<a single point> takes a different branch (kp = [k]); smoke test
+    it wasn't broken by batching the mesh case."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    es, vs = get_eigenvectors(h, k=np.array([0.1, 0.2, 0.0]))
+    assert es.shape[0] == h.intra.shape[0]

--- a/tests/parallel/test_six_more_thread_independence.py
+++ b/tests/parallel/test_six_more_thread_independence.py
@@ -1,0 +1,99 @@
+import numpy as np
+import numba
+
+from pyqula import geometry
+from pyqula.filling import eigenvalues as filling_eigenvalues
+from pyqula.spectrum import total_energy
+from pyqula.fermisurface import fermi_surface_generator
+from pyqula.htk.eigenvectors import get_eigenvectors
+from pyqula.ldos import ldosmap
+from pyqula.kdos import kdos_bands
+
+
+def test_eigenvalue_only_functions_independent_of_thread_count():
+    """filling.eigenvalues, spectrum.total_energy, and
+    fermisurface.fermi_surface_generator all batch their diagonalization
+    through htk.eigenvectors.peigvalsh (eigenvalues only); none of their
+    results should depend on how many numba threads did the work --
+    i.e. serial (1 thread) and parallel (2, 4 threads) execution must
+    agree exactly."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    default_threads = numba.get_num_threads()
+    try:
+        cases = {
+            "filling.eigenvalues":
+                lambda: np.sort(filling_eigenvalues(h, nk=6)),
+            "spectrum.total_energy":
+                lambda: total_energy(h, nk=6, mode="mesh"),
+            "fermi_surface_generator":
+                lambda: fermi_surface_generator(h, energies=[0.0, 0.2], nk=5, delta=0.1)[2],
+        }
+        for name, f in cases.items():
+            results = []
+            for n in (1, 2, 4): # serial, then increasingly parallel
+                numba.set_num_threads(n)
+                results.append(f())
+            for r in results[1:]:
+                assert np.allclose(r, results[0]), \
+                    f"{name}: result depends on numba thread count"
+    finally:
+        numba.set_num_threads(default_threads)
+
+
+def test_eigenvector_based_functions_independent_of_thread_count(tmp_path, monkeypatch):
+    """htk.eigenvectors.get_eigenvectors, ldos.ldosmap, and
+    kdos.kdos_bands all batch full diagonalization (eigenvectors, not
+    just eigenvalues) through parallel_diagonalization; same check as
+    above, serial vs. parallel execution."""
+    monkeypatch.chdir(tmp_path)
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    default_threads = numba.get_num_threads()
+    try:
+        # get_eigenvectors: compare via the phase-invariant density-matrix
+        # sum -- individual eigenvector phases aren't guaranteed stable
+        # across independently-threaded diagonalizations of the same
+        # matrix, even though the eigenspace they span is (see
+        # tests/parallel/test_get_eigenvectors_dense.py).
+        dms = []
+        for n in (1, 2, 4):
+            numba.set_num_threads(n)
+            es, vs = get_eigenvectors(h, nk=5)
+            dms.append(np.conj(vs).T @ vs)
+        for dm in dms[1:]:
+            assert np.allclose(dm, dms[0], atol=1e-8), \
+                "get_eigenvectors: result depends on numba thread count"
+
+        # ldosmap draws its own random kpoints internally; pin them so
+        # only the thread count varies between runs (see
+        # tests/ldos/test_ldosmap.py for why naive seeding isn't enough).
+        energies = np.linspace(-1, 1, 10)
+        rng = np.random.RandomState(0)
+        ks = [rng.random(3) for _ in range(6)]
+        ds_all = []
+        for n in (1, 2, 4):
+            it = iter(ks)
+            monkeypatch.setattr(np.random, "random", lambda *a, **kw: next(it))
+            numba.set_num_threads(n)
+            _, ds = ldosmap(h, energies=energies, delta=0.1, nk=6)
+            ds_all.append(ds)
+        for d in ds_all[1:]:
+            assert np.allclose(d, ds_all[0]), \
+                "ldosmap: result depends on numba thread count"
+
+        # kdos_bands, mode="ED"
+        kpath = h.geometry.get_kpath(None, nk=6)
+        kenergies = np.linspace(-3, 3, 30)
+        out_all = []
+        for n in (1, 2, 4):
+            numba.set_num_threads(n)
+            out = kdos_bands(h, kpath=kpath, energies=kenergies, delta=0.1, mode="ED")
+            out_all.append(out[2])
+        for o in out_all[1:]:
+            assert np.allclose(o, out_all[0]), \
+                "kdos_bands: result depends on numba thread count"
+    finally:
+        numba.set_num_threads(default_threads)

--- a/tests/parallel/test_total_energy.py
+++ b/tests/parallel/test_total_energy.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from pyqula import geometry, algebra
+from pyqula.spectrum import total_energy
+
+
+def test_total_energy_mesh_matches_serial_reference():
+    """total_energy's default (mesh, dense, no KPM/num_bands) case is now
+    batched through numba prange; check it still agrees with the plain
+    per-kpoint loop it replaced."""
+    from pyqula.klist import kmesh
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    nk = 6
+    new = total_energy(h, nk=nk, mode="mesh")
+
+    f = h.get_hk_gen()
+    kp = kmesh(h.dimensionality, nk=nk)
+    old = np.mean([np.sum(algebra.eigvalsh(f(k))[algebra.eigvalsh(f(k)) < 0.0]) for k in kp])
+    assert abs(new - old) < 1e-8
+
+
+def test_total_energy_random_matches_serial_reference(monkeypatch):
+    """Same, for mode='random' -- kpoints are drawn from np.random, so use
+    a fixed stand-in to guarantee both paths see identical kpoints
+    (see tests/ldos/test_ldosmap.py for why this matters)."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    nk = 8
+    rng = np.random.RandomState(0)
+    ks = [rng.random(3) for _ in range(nk)]
+
+    it = iter(ks)
+    monkeypatch.setattr(np.random, "random", lambda *a, **kw: next(it))
+    new = total_energy(h, nk=nk, mode="random")
+
+    f = h.get_hk_gen()
+    old = np.mean([np.sum(algebra.eigvalsh(f(k))[algebra.eigvalsh(f(k)) < 0.0]) for k in ks])
+    assert abs(new - old) < 1e-8
+
+
+def test_total_energy_kpm_and_num_bands_still_use_pcall_path():
+    """Smoke test: use_kpm and num_bands both fall back to the original
+    pcall path and shouldn't be affected by the batched-mesh change --
+    confirmed by running the exact same calls against the pre-change
+    code (git stash) and getting the identical (pre-existing, NaN for
+    use_kpm on this particular tiny test system) result, so this test
+    only pins down that the routing/branching wasn't broken, not the
+    numerical output of a path this change doesn't touch."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    e_kpm = total_energy(h, nk=4, mode="mesh", use_kpm=True) # noqa: F841 (just must not raise)
+    e_nb = total_energy(h, nk=4, mode="mesh", nbands=2)
+    assert np.isfinite(e_nb)


### PR DESCRIPTION
## PR #22 was merged after only its first commit — this brings in the rest

Same situation as #18→#19: #22 got merged (into \`bands-dos-numba\`) right after its first commit (\`3785e97\`, fermi_surface/get_qpi), before the two follow-up commits on the same branch were merged. Nothing was lost — they're still here — but they never made it into \`bands-dos-numba\`. This PR is just those two commits.

## Summary

**First commit** — six more items from the [pcall inventory/roadmap](https://claude.ai/code/artifact/e3e91b81-85dd-4556-8733-d0541b0f88db) (§14/§15):

1. \`filling.eigenvalues\`, 2. \`htk/eigenvectors.get_eigenvectors\` (dense), 3. \`fermisurface.fermi_surface_generator\`, 4. \`spectrum.total_energy\`, 5. \`ldos.ldosmap\`, 6. \`kdos.kdos_bands\` (ED mode — the one that needed real restructuring, since it previously wrapped many cheap single-kpoint \`h.get_dos\` calls in an outer process pool).

Measured at exactly 4 numba threads, against each function's original per-kpoint implementation:

| Size | 1. eigenvalues | 2. get_eigenvectors | 3. fermi_surface_gen | 4. total_energy | 5. ldosmap | 6. kdos_bands |
|---|---|---|---|---|---|---|
| 2 sites | 4.37x | 1.60x | 2.27x | 2.82x | 181.6x* | 2.73x |
| 50 sites | 1.06x | 3.44x | 1.22x | 2.00x | 1.65x | 3.95x |
| 200 sites | **0.98x** | 2.82x | **0.96x** | 1.92x | 2.00x | 3.38x |

*Almost certainly a warmup artifact (~1ms raw times). Not smoothed over: items 1 and 3 essentially break even at 200 sites — real result, reason not obvious from the code, flagged as open rather than hidden.

**Second commit** — two tests comparing serial (1 numba thread) vs. parallel (2, 4 threads) execution across all six functions above, confirming results are identical regardless of thread count.

Also found along the way (neither caused by this change, documented in the plan artifact §15): a JAX import-time side effect that silently consumes global `np.random` state, and a pre-existing NaN in \`total_energy\`'s KPM path unrelated to this PR.

## Test plan

- [x] \`python -m pytest tests\` — 53 passed, 0 regressions
- [x] All six conversions verified against inlined serial reference implementations
- [x] Serial-vs-parallel (thread count 1/2/4) equivalence verified for all six

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7TkHmpFfRb2tuLx8GnVT7