### PR TITLE
Fix sparse-Hamiltonian crash in numba-batched diagonalization call sites

### DIFF
--- a/src/pyqula/bandstructure.py
+++ b/src/pyqula/bandstructure.py
@@ -127,12 +127,12 @@ def get_bands_nd(h,kpath=None,operator=None,num_bands=None,
         if len(rows)==0: return np.empty((0,ncols))
         return np.array(rows)
     if num_bands is None: # all the bands: batched, numba-parallel diagonalization
-        from .htk.eigenvectors import parallel_diagonalization, peigvalsh
+        from .htk.eigenvectors import parallel_diagonalization, peigvalsh, hk_matrix_batch
         nkp = len(kpath)
         rows_all = []
         for i0 in range(0,nkp,batch_size): # loop over batches of kpoints
             kbatch = range(i0,min(i0+batch_size,nkp))
-            mats = np.array([hkgen(kpath[k]) for k in kbatch],dtype=np.complex128)
+            mats = hk_matrix_batch(hkgen,[kpath[k] for k in kbatch])
             if operator is None:
                 es_batch = peigvalsh(mats) # eigenvalues only, diagonalized in parallel
                 for ii,k in enumerate(kbatch):

--- a/src/pyqula/densitymatrix.py
+++ b/src/pyqula/densitymatrix.py
@@ -37,14 +37,14 @@ def full_dm_accumulate(h,nk=10,fermi=0.0,
     bounds how many k-points' eigenvectors are held in memory at once,
     keeping the memory footprint low regardless of how dense the k-mesh
     is."""
-    from .htk.eigenvectors import parallel_diagonalization
+    from .htk.eigenvectors import parallel_diagonalization, hk_matrix_batch
     hk = h.get_hk_gen() # get the Hamiltonian generator
     ks = np.array(h.geometry.get_kmesh(nk=nk)) # get the mesh
     fac = 1./len(ks) # normalization
     dm = None # accumulator, one slot per batch
     for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
         kbatch = ks[i0:i0+batch_size]
-        mats = np.array([hk(k) for k in kbatch]) # k-Hamiltonians in this batch
+        mats = hk_matrix_batch(hk,kbatch) # k-Hamiltonians in this batch
         es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize in parallel
         es_batch = es_batch-fermi # substract fermi energy
         if ds is None:

--- a/src/pyqula/fermisurface.py
+++ b/src/pyqula/fermisurface.py
@@ -83,12 +83,12 @@ def fermi_surface_generator(h,
     kdos = np.zeros((len(rs),len(energies))) # initialize
     if mode=='full' and operator is None:
         # batched, numba-parallel path -- no interprocess dispatch
-        from .htk.eigenvectors import peigvalsh
+        from .htk.eigenvectors import peigvalsh, hk_matrix_batch
         ks = np.array([fR(r) for r in rs]) # kpoints, change of basis applied
         batch_size = 64
         for i0 in range(0,len(rs),batch_size): # loop over batches of kpoints
             kbatch = ks[i0:i0+batch_size]
-            mats = np.array([hk_gen(k) for k in kbatch],dtype=np.complex128)
+            mats = hk_matrix_batch(hk_gen,kbatch)
             es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
             for ii in range(len(kbatch)):
                 kdos[i0+ii,:] = fermi_weight(es_batch[ii],energies,delta=delta)

--- a/src/pyqula/fermisurfacetk/singlefs.py
+++ b/src/pyqula/fermisurfacetk/singlefs.py
@@ -95,13 +95,13 @@ def fermi_surface(h,write=True,output_file="FERMI_MAP.OUT",
     kyout = rs[:,1] # y coordinate
     if mode=='eigen' and operator is None:
         # batched, numba-parallel path -- no interprocess dispatch
-        from ..htk.eigenvectors import peigvalsh
+        from ..htk.eigenvectors import peigvalsh, hk_matrix_batch
         ks = np.array([R(r)+k0 for r in rs]) # kpoints, change of basis applied
         kdos = np.zeros(len(rs),dtype=np.float64)
         batch_size = 64
         for i0 in range(0,len(rs),batch_size): # loop over batches of kpoints
             kbatch = ks[i0:i0+batch_size]
-            mats = np.array([hk_gen(k) for k in kbatch],dtype=np.complex128)
+            mats = hk_matrix_batch(hk_gen,kbatch)
             es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
             for ii in range(len(kbatch)):
                 es = es_batch[ii]

--- a/src/pyqula/filling.py
+++ b/src/pyqula/filling.py
@@ -23,7 +23,7 @@ def get_fermi_energy(es,filling,fermi_shift=0.0,
 def eigenvalues(h0,nk=10,notime=True,batch_size=64):
     """Return all the eigenvalues of a Hamiltonian"""
     from . import klist
-    from .htk.eigenvectors import peigvalsh
+    from .htk.eigenvectors import peigvalsh, hk_matrix_batch
     h = h0.copy() # copy hamiltonian
     h = h.get_dense()
     ks = klist.kmesh(h.dimensionality,nk=nk) # get grid
@@ -31,7 +31,7 @@ def eigenvalues(h0,nk=10,notime=True,batch_size=64):
     es_all = [] # list of batches
     for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
         kbatch = ks[i0:i0+batch_size]
-        mats = np.array([hkgen(k) for k in kbatch],dtype=np.complex128)
+        mats = hk_matrix_batch(hkgen,kbatch)
         es_all.append(peigvalsh(mats)) # diagonalize the whole batch in parallel
     es = np.concatenate(es_all,axis=0)
     es = es.reshape(es.shape[0]*es.shape[1])

--- a/src/pyqula/htk/eigenvectors.py
+++ b/src/pyqula/htk/eigenvectors.py
@@ -4,6 +4,17 @@ from ..klist import kmesh
 import numpy as np
 import scipy.sparse.linalg as slg
 
+
+def hk_matrix_batch(f,ks):
+  """Evaluate a Hamiltonian generator f at every k in ks and stack the
+  results into one dense complex128 array, densifying any sparse output
+  along the way (see algebra.todense). Every call site that batches
+  k-point Hamiltonians for parallel_diagonalization/peigvalsh should go
+  through this, so a sparse Hamiltonian never reaches numba's dense eigh
+  as a scipy sparse matrix (which numba cannot handle)."""
+  return np.array([algebra.todense(f(k)) for k in ks],dtype=np.complex128)
+
+
 def get_eigenvectors(h,nk=10,kpoints=False,k=None,sparse=False,
         numw=None,energy=0.0):
   from scipy.sparse import csc_matrix as csc
@@ -32,7 +43,7 @@ def get_eigenvectors(h,nk=10,kpoints=False,k=None,sparse=False,
       vvs = []
       for i0 in range(0,len(kp),batch_size): # loop over batches of kpoints
         kbatch = kp[i0:i0+batch_size]
-        mats = np.array([f(kk) for kk in kbatch],dtype=np.complex128)
+        mats = hk_matrix_batch(f,kbatch)
         es_batch,ws_batch = parallel_diagonalization(mats) # diagonalize the batch in parallel
         for ii in range(len(kbatch)): vvs.append((es_batch[ii],ws_batch[ii]))
     nume = sum([len(v[0]) for v in vvs]) # number of eigenvalues calculated

--- a/src/pyqula/ldos.py
+++ b/src/pyqula/ldos.py
@@ -163,14 +163,14 @@ def ldosmap(h,energies=np.linspace(-1.0,1.0,40),delta=None,
   ks = [np.random.random(3) for ik in range(nk)] # kpoints
   if kwargs.get("num_bands") is None and not kwargs.get("non_hermitian",False):
       # batched, numba-parallel path -- no interprocess dispatch
-      from .htk.eigenvectors import parallel_diagonalization
+      from .htk.eigenvectors import parallel_diagonalization, hk_matrix_batch
       from .ldostk.ldoswaves import ldos_waves_from_eigsystem
       delta_discard = kwargs.get("delta_discard")
       ds = []
       batch_size = 64
       for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
           kbatch = ks[i0:i0+batch_size]
-          mats = np.array([hkgen(k) for k in kbatch],dtype=np.complex128)
+          mats = hk_matrix_batch(hkgen,kbatch)
           es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize the batch in parallel
           for ii,k in enumerate(kbatch):
               eigvec = vs_batch[ii].T # rows are eigenvectors

--- a/src/pyqula/spectrum.py
+++ b/src/pyqula/spectrum.py
@@ -246,7 +246,7 @@ def total_energy(h,nk=10,nbands=None,use_kpm=False,random=False,
   # compute energy using different modes
   if mode in ("mesh","random") and (not use_kpm) and nbands is None:
     # batched, numba-parallel path -- no interprocess dispatch
-    from .htk.eigenvectors import peigvalsh
+    from .htk.eigenvectors import peigvalsh, hk_matrix_batch
     if mode=="mesh":
         from .klist import kmesh
         kp = kmesh(h.dimensionality,nk=nk)
@@ -256,7 +256,7 @@ def total_energy(h,nk=10,nbands=None,use_kpm=False,random=False,
     batch_size = 64
     for i0 in range(0,len(kp),batch_size): # loop over batches of kpoints
         kbatch = kp[i0:i0+batch_size]
-        mats = np.array([f(k) for k in kbatch],dtype=np.complex128)
+        mats = hk_matrix_batch(f,kbatch)
         es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
         for es in es_batch: sums.append(np.sum(es[es<fermi]))
     etot = np.mean(sums) # compute total energy
@@ -394,11 +394,11 @@ def eigenvalues_kmesh(h,nk=20,batch_size=64):
     hkgen = h.get_hk_gen() # get the generator
     kx = np.linspace(0.,1.,nk,endpoint=False)
     ky = np.linspace(0.,1.,nk,endpoint=False)
-    from .htk.eigenvectors import peigvalsh
+    from .htk.eigenvectors import peigvalsh, hk_matrix_batch
     ijs = [(i,j) for i in range(nk) for j in range(nk)] # flat list of grid indices
     for i0 in range(0,len(ijs),batch_size): # loop over batches of kpoints
         ijbatch = ijs[i0:i0+batch_size]
-        mats = np.array([hkgen([kx[i],ky[j]]) for (i,j) in ijbatch],dtype=np.complex128)
+        mats = hk_matrix_batch(lambda ij: hkgen([kx[ij[0]],ky[ij[1]]]),ijbatch)
         es_batch = peigvalsh(mats) # diagonalize the whole batch in parallel
         for ii,(i,j) in enumerate(ijbatch):
             es[i,j,:] = es_batch[ii] # store energies

--- a/tests/parallel/test_sparse_hamiltonian_batching.py
+++ b/tests/parallel/test_sparse_hamiltonian_batching.py
@@ -1,0 +1,125 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.htk.eigenvectors import get_eigenvectors, hk_matrix_batch
+from pyqula.spectrum import eigenvalues_kmesh, total_energy
+from pyqula.filling import eigenvalues as filling_eigenvalues
+from pyqula.fermisurface import fermi_surface_generator
+from pyqula.ldos import ldosmap
+from pyqula.densitymatrix import full_dm_accumulate
+
+
+def _dense_and_sparse():
+    """A small Hamiltonian and a sparse copy of it, both built the same
+    way -- used to check the numba-prange batching in htk/eigenvectors.py,
+    bandstructure.py, fermisurfacetk/singlefs.py, ldos.py, spectrum.py,
+    filling.py, fermisurface.py, and densitymatrix.py all go through
+    hk_matrix_batch (which densifies each k-point matrix via
+    algebra.todense before stacking), so a sparse Hamiltonian never
+    reaches numba's dense eigh as a scipy sparse matrix -- previously a
+    TypeError: must be real number, not csc_matrix."""
+    g = geometry.honeycomb_lattice()
+    h = g.get_hamiltonian()
+    h.add_zeeman([0., 0., 0.3])
+    hs = h.copy()
+    hs.turn_sparse()
+    return h, hs
+
+
+def test_hk_matrix_batch_densifies_sparse_output():
+    """Direct unit test of the shared helper: it must return a dense
+    complex128 array regardless of whether f(k) returns a scipy sparse
+    matrix or a dense one, and the two must agree numerically."""
+    h, hs = _dense_and_sparse()
+    f = h.get_hk_gen()
+    fs = hs.get_hk_gen()
+    ks = [[0.1, 0.2, 0.], [0.3, -0.1, 0.]]
+    dense_batch = hk_matrix_batch(f, ks)
+    sparse_batch = hk_matrix_batch(fs, ks)
+    assert dense_batch.dtype == np.complex128
+    assert sparse_batch.dtype == np.complex128
+    assert type(sparse_batch) is np.ndarray  # genuinely dense, not scipy sparse
+    assert np.allclose(dense_batch, sparse_batch)
+
+
+def test_get_eigenvectors_dense_branch_does_not_crash_on_sparse():
+    h, hs = _dense_and_sparse()
+    es_dense, _ = get_eigenvectors(h, nk=4)
+    es_sparse, _ = get_eigenvectors(hs, nk=4)
+    assert np.allclose(np.sort(es_dense), np.sort(es_sparse))
+
+
+def test_get_bands_default_path_does_not_crash_on_sparse():
+    h, hs = _dense_and_sparse()
+    _, e_dense = h.get_bands(nk=4, write=False)
+    _, e_sparse = hs.get_bands(nk=4, write=False)
+    assert np.allclose(np.sort(e_dense), np.sort(e_sparse))
+
+
+def test_get_fermi_surface_default_mode_does_not_crash_on_sparse():
+    h, hs = _dense_and_sparse()
+    _, _, kdos_dense = h.get_fermi_surface(nk=4, e=0.1, delta=0.1, write=False)
+    _, _, kdos_sparse = hs.get_fermi_surface(nk=4, e=0.1, delta=0.1, write=False)
+    assert np.allclose(kdos_dense, kdos_sparse)
+
+
+def test_eigenvalues_kmesh_does_not_crash_on_sparse():
+    h, hs = _dense_and_sparse()
+    es_dense = np.sort(eigenvalues_kmesh(h, nk=4).reshape(-1))
+    es_sparse = np.sort(eigenvalues_kmesh(hs, nk=4).reshape(-1))
+    assert np.allclose(es_dense, es_sparse)
+
+
+def test_ldosmap_does_not_crash_on_sparse(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    h, hs = _dense_and_sparse()
+    energies = np.linspace(-1, 1, 5)
+    # pin the internally-drawn random kpoints so dense and sparse see the
+    # same ones (see tests/ldos/test_ldosmap.py for why plain seeding
+    # isn't enough)
+    rng = np.random.RandomState(0)
+    ks = [rng.random(3) for _ in range(4)]
+    it = iter(ks)
+    monkeypatch.setattr(np.random, "random", lambda *a, **kw: next(it))
+    _, ds_dense = ldosmap(h, energies=energies, delta=0.1, nk=4)
+    it = iter(ks)
+    monkeypatch.setattr(np.random, "random", lambda *a, **kw: next(it))
+    _, ds_sparse = ldosmap(hs, energies=energies, delta=0.1, nk=4)
+    assert np.allclose(ds_dense, ds_sparse)
+
+
+def test_filling_eigenvalues_still_works_on_sparse_input():
+    """filling.eigenvalues already called h.get_dense() before batching,
+    so it never crashed -- pin it down so a future change can't quietly
+    drop that guard."""
+    h, hs = _dense_and_sparse()
+    es_dense = np.sort(filling_eigenvalues(h, nk=4))
+    es_sparse = np.sort(filling_eigenvalues(hs, nk=4))
+    assert np.allclose(es_dense, es_sparse)
+
+
+def test_total_energy_still_works_on_sparse_input():
+    """Same guard, for spectrum.total_energy (calls h.get_dense() when
+    nbands is None, before the batched mode='mesh' path runs)."""
+    h, hs = _dense_and_sparse()
+    e_dense = total_energy(h, nk=4, mode="mesh")
+    e_sparse = total_energy(hs, nk=4, mode="mesh")
+    assert abs(e_dense - e_sparse) < 1e-8
+
+
+def test_fermi_surface_generator_still_works_on_sparse_input():
+    """fermi_surface_generator derives mode from h.is_sparse itself
+    (mode='sparse' vs 'full'), so a sparse Hamiltonian is routed away
+    from the batched path entirely -- not exercising hk_matrix_batch,
+    but pinned here so the routing isn't broken by future changes."""
+    h, hs = _dense_and_sparse()
+    _, _, kdos_dense = fermi_surface_generator(h, energies=[0.0, 0.2], nk=5, delta=0.1)
+    _, _, kdos_sparse = fermi_surface_generator(hs, energies=[0.0, 0.2], nk=5, delta=0.1)
+    assert np.allclose(kdos_dense, kdos_sparse)
+
+
+def test_full_dm_accumulate_does_not_crash_on_sparse():
+    h, hs = _dense_and_sparse()
+    dm_dense = full_dm_accumulate(h, nk=4)
+    dm_sparse = full_dm_accumulate(hs, nk=4)
+    assert np.allclose(dm_dense, dm_sparse)


### PR DESCRIPTION
## Summary
- Fixes 5 crashes (`get_eigenvectors`, `get_bands`/`get_bands_nd`, `get_fermi_surface`, `ldosmap`, `eigenvalues_kmesh`/`get_qpi`) found by `/code-review` on PR #23: these batched-diagonalization call sites built `np.array([f(k) for k in kbatch], dtype=complex128)` directly from the k-Hamiltonian generator with no guard for sparse output, unlike the `algebra.eigh`/`eigvalsh` path they replaced (which densified transparently via `algebra.todense`). Any sparse Hamiltonian reaching these paths raised `TypeError: must be real number, not csc_matrix`.
- Adds `htk.eigenvectors.hk_matrix_batch`, a shared helper that densifies each k-point matrix via `algebra.todense` before stacking, and routes all 8 flagged batching call sites plus `densitymatrix.full_dm_accumulate` (same pattern, pre-existing) through it — also eliminating the duplicated batching idiom flagged separately by the review.
- Adds `tests/parallel/test_sparse_hamiltonian_batching.py`: for each affected entry point, builds a dense and a sparse (`h.turn_sparse()`) copy of the same Hamiltonian and checks both no longer crash and produce numerically identical results. Verified the tests actually catch the regression by reverting the fix (`git stash`) and confirming they fail against the pre-fix code.

## Test plan
- [x] `python -m pytest tests -q` — 63 passed (full suite, including the 10 new tests)
- [x] Manually reproduced all 5 crashes against pre-fix code, confirmed fixed
- [x] New tests fail against reverted (pre-fix) source, pass against the fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01E7TkHmpFfRb2tuLx8GnVT7