### PR TITLE
Compute decay-constant kappa via Keldysh when the probe lead is superconducting

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ From the [Jyvaskyla Summer School 2022](https://github.com/joselado/jyvaskyla_su
 - Fully non-collinear Nambu basis
 - Non-equilibrium Green's function formalism
 - Operator-resolved transport
-- Multiple Andreev reflection and AC-Josephson current between two superconductors (Floquet-Keldysh formalism)
+- Multiple Andreev reflection and AC-Josephson current between two superconductors (Floquet-Keldysh formalism), including a superconducting local (STM-like) probe
 
 ## Classical spin models and lattice-gas Monte Carlo ##
 - Classical Heisenberg spin models with arbitrary exchange couplings

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -1237,6 +1237,23 @@ Is = HT.get_iv_curve(vs) # MAR/AC-Josephson dc current
 
 The number of Floquet sidebands is increased adaptively (as in the paper) until $I_{dc}$ converges; see `examples/transport/floquet_keldysh_mar/main.py` for a runnable script and `tests/keldysh/` for correctness tests (a normal-normal junction must reduce exactly to a directly biased, non-Floquet Landauer calculation, and a normal-superconductor junction's zero-bias slope must match the existing equilibrium Andreev conductance from `didv`). Only 1D leads directly coupled through a single "weak link" bond (`heterostructures.build(h1,h2)` with no explicit `central=` Hamiltonian) are supported; `get_dc_current` raises `NotImplementedError` for a heterostructure with an explicit central region, since testing found a confirmed, unresolved systematic error there whenever that region is not structurally identical to a lead.
 
+`transporttk.localprobe.LocalProbe` models a single STM-like tip weakly coupled to one site of an infinite/bulk sample (used e.g. for `get_kappa`, a decay-constant/transparency-scaling diagnostic -- see `examples/transport/decay_constant/main.py`). The same routing applies there: `LocalProbe.didv`/`get_kappa` use the ordinary scattering-matrix formula by default, but switch to the Floquet-Keldysh MAR current when the probe lead (`lp.lead`) is itself superconducting *and* the sample is superconducting too, since a normal-metal probe no longer applies and the same "no normal lead to reflect against" problem as above appears. The probe's unit cell and the sample's local (single-site) Hamiltonian play the role of the two leads.
+
+```python
+from pyqula import geometry
+from pyqula.transporttk.localprobe import LocalProbe
+
+g = geometry.chain()
+h = g.get_hamiltonian() ; h.shift_fermi(1.) ; h.add_swave(0.1) # SC sample
+lead = geometry.chain().get_hamiltonian() ; lead.shift_fermi(1.) ; lead.add_swave(0.1) # SC probe
+lp = LocalProbe(h,lead=lead,delta=1e-3)
+lp.T = 0.3 # reference transparency
+G = lp.didv(energy=0.25,nmax=4,nmax_max=12,tol=5e-2) # routed through Keldysh automatically
+k = lp.get_kappa(energy=0.25,nmax=4,nmax_max=12,tol=5e-2)
+```
+
+This is considerably more expensive than the normal-probe case (each `didv`/`get_kappa` call runs several Floquet-Keldysh sideband sweeps), especially deep below the combined gap at low transparency, where the sideband sum converges slowly; see `examples/transport/decay_constant_keldysh/main.py` for a runnable script using a coarse energy grid and a modest sideband cutoff to keep the runtime reasonable.
+
 
 # Single defects in infinite systems
 

--- a/examples/transport/decay_constant_keldysh/main.py
+++ b/examples/transport/decay_constant_keldysh/main.py
@@ -1,0 +1,50 @@
+# Add the root path of the pyqula library
+import os ; import sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__))+"/../../../src")
+
+
+from pyqula import geometry
+from pyqula.transporttk.localprobe import LocalProbe
+import numpy as np
+import matplotlib.pyplot as plt
+
+## Same idea as examples/transport/decay_constant, but with a
+## superconducting probe (instead of the default normal-metal STM tip).
+## With both the probe and the sample superconducting, the ordinary
+## scattering-matrix formula behind LocalProbe.didv no longer applies (it
+## has no normal lead left to define a reflection amplitude against), so
+## LocalProbe.didv/get_kappa automatically route through the
+## Floquet-Keldysh multiple-Andreev-reflection (MAR) current instead --
+## see Heterostructure.get_dc_current and the "Multiple Andreev
+## reflection" section of the user guide. This is *much* more expensive
+## than the normal-probe case, so this example uses a coarse energy grid
+## and a modest Floquet sideband cutoff (nmax_max) ##
+
+g = geometry.chain()
+h = g.get_hamiltonian()
+h.shift_fermi(1.) # shift the chemical potential
+D = 0.1 # superconducting gap of the sample
+h.add_swave(D) # pairing gap of the sample
+
+Dtip = 0.1 # superconducting gap of the probe (STM tip)
+lead = geometry.chain().get_hamiltonian()
+lead.shift_fermi(1.)
+lead.add_swave(Dtip) # the probe lead is itself superconducting
+
+lp = LocalProbe(h,lead=lead,delta=1e-3) # superconducting local probe
+lp.T = 0.3 # reference transparency
+kwargs = dict(nmax=4,nmax_max=12,tol=5e-2) # keep the Floquet sideband sweep cheap
+
+Dsum = D+Dtip # onset of single-quasiparticle transport (MAR order n=1)
+es = np.linspace(1.05*Dsum,1.6*Dsum,7) # energies above the SIS gap sum
+ts = [lp.didv(energy=e,**kwargs) for e in es] # dIdV (method="auto" -> "keldysh")
+ks = [lp.get_kappa(energy=e,**kwargs) for e in es] # decay rate from the MAR current
+
+plt.subplot(121)
+plt.plot(es/Dsum,ts,marker="o")
+plt.xlabel("Energy/$(\\Delta+\\Delta_{tip})$") ; plt.ylabel("dIdV")
+plt.subplot(122)
+plt.plot(es/Dsum,ks,marker="o")
+plt.xlabel("Energy/$(\\Delta+\\Delta_{tip})$") ; plt.ylabel("$\\kappa/\\kappa_N$")
+plt.tight_layout()
+plt.show()

--- a/src/pyqula/keldyshtk/current.py
+++ b/src/pyqula/keldyshtk/current.py
@@ -46,6 +46,11 @@ def lesser_from_retarded(sigma_r, energy, temperature=0.):
     return -f*(sigma_r - dagger(sigma_r))
 
 
+def _is_localprobe(ht):
+    from ..transporttk.localprobe import LocalProbe
+    return isinstance(ht, LocalProbe)
+
+
 def _check_supported(ht):
     if getattr(ht, "dimensionality", 1) != 1:
         raise NotImplementedError(
@@ -54,6 +59,8 @@ def _check_supported(ht):
         raise NotImplementedError(
             "keldysh.dc_current needs a Nambu (BdG) heterostructure; "
             "call h.turn_nambu() on both leads first (even with zero pairing)")
+    if _is_localprobe(ht):
+        return  # a LocalProbe has no explicit central region by construction
     if not (ht.block_diagonal and len(ht.central_intra) == 0):
         raise NotImplementedError(
             "keldysh.dc_current only supports heterostructures with no "
@@ -64,11 +71,38 @@ def _check_supported(ht):
             "that case is rejected until it is root-caused")
 
 
+def _prepare_system_localprobe(lp):
+    """Build the 2-block (probe, sample-site) chain and the electron/hole
+    projectors for a LocalProbe, mirroring `_prepare_system` below: block 0
+    is the probe's unit cell (`lp.lead`), block 1 is the single bulk site
+    being probed (`lp.i` of `lp.H`), and the AC-carrying bond is the
+    probe-sample tunneling link scaled by the transparency `lp.T` -- the
+    same raw Hamiltonian block structure `localprobe.get_central_gmatrix`
+    dresses with self-energies and (energy+i*delta) for the smatrix method."""
+    from ..htk.extract import local_hamiltonian
+    from ..transporttk.localprobe import get_intra
+    oi = algebra.todense(local_hamiltonian(lp.H, get_intra(lp.H), i=lp.i))
+    h01 = algebra.todense(lp.lead.inter)*lp.T  # probe -> sample-site bond
+    hlist = [[algebra.todense(lp.lead.intra), h01],
+             [dagger(h01), oi]]
+    proje = algebra.todense(local_hamiltonian(
+        lp.H, lp.H.get_operator("electron").get_matrix(), i=lp.i))
+    projh = algebra.todense(local_hamiltonian(
+        lp.H, lp.H.get_operator("hole").get_matrix(), i=lp.i))
+    dim = hlist[0][0].shape[0]
+    if proje.shape[0] != dim:
+        raise ValueError("dimension mismatch between the probe lead and "
+                          "the local sample site")
+    return hlist, proje, projh, dim
+
+
 def _prepare_system(ht):
     """Build the 2-block chain (one extra unit cell of each lead, directly
     weak-linked) and the electron/hole projectors for the right lead, whose
     unit cell is the target of the AC-carrying bond."""
     _check_supported(ht)
+    if _is_localprobe(ht):
+        return _prepare_system_localprobe(ht)
     hlist = enlarge_hlist(ht).central_intra
     proje = algebra.todense(ht.Hr.get_operator("electron").get_matrix())
     projh = algebra.todense(ht.Hr.get_operator("hole").get_matrix())
@@ -110,6 +144,8 @@ def _prefetch_selfenergies_batch(ht, es, lead, delta, cache):
     loop across threads. `_cached_selfenergy` below then just hits the
     cache this fills in; the tolerance matches the non-batched path
     exactly, so this only changes speed, never the result."""
+    if not hasattr(ht, "get_selfenergy_batch"):
+        return  # e.g. LocalProbe: fall back to per-energy _cached_selfenergy
     keys = [(lead, round(e, 10)) for e in es]
     miss = [i for i, k in enumerate(keys) if k not in cache]
     if not miss: return
@@ -275,12 +311,30 @@ def current_integrand(ht, voltage, quasienergy, nmax, tauz,
     return total.real
 
 
+def _prepare_bias_target(ht):
+    """LocalProbe's `frozen_lead` (True by default) locks the probe's
+    self-energy at zero energy for every bias -- a fine approximation for
+    a normal, wide-band probe (the smatrix method's default), but wrong
+    for a superconducting probe, whose self-energy has genuine gap
+    structure that must be evaluated at each Floquet sideband energy.
+    Return a copy with `frozen_lead=False` so the Keldysh sideband sweep
+    below sees the probe's real energy dependence; leave non-LocalProbe
+    heterostructures untouched."""
+    if _is_localprobe(ht) and ht.frozen_lead:
+        ht = ht.copy()
+        ht.frozen_lead = False
+    return ht
+
+
 def dc_current(ht, voltage, nmax=6, nmax_max=40, tol=1e-3, temperature=0.,
                delta=None):
-    """Time-averaged (DC) current through a two-terminal junction (two
-    leads, no explicit central region) under a bias `voltage`, computed
-    with the Floquet-Keldysh formalism of San-Jose, Cayao, Prada, Aguado,
-    NJP 15, 075019 (2013).
+    """Time-averaged (DC) current through a two-terminal junction under a
+    bias `voltage`, computed with the Floquet-Keldysh formalism of
+    San-Jose, Cayao, Prada, Aguado, NJP 15, 075019 (2013). The junction is
+    either a two-lead heterostructure with no explicit central region
+    (heterostructures.build(h1,h2)) or a LocalProbe (probe tip weakly
+    coupled to a single site of a bulk sample) whose probe and sample are
+    both superconducting.
 
     The number of Floquet sidebands is increased adaptively (as in the
     paper) until the result changes by less than `tol`, capped at
@@ -288,10 +342,12 @@ def dc_current(ht, voltage, nmax=6, nmax_max=40, tol=1e-3, temperature=0.,
     hit before convergence)."""
     if voltage == 0.:
         return 0.0
+    ht = _prepare_bias_target(ht)
     _check_supported(ht)
     if delta is None:
         delta = ht.delta
-    tauz = algebra.todense(ht.Hl.get_operator("tauz").get_matrix())
+    lead0 = ht.lead if _is_localprobe(ht) else ht.Hl
+    tauz = algebra.todense(lead0.get_operator("tauz").get_matrix())
     cache = {}
 
     def integral(nmax):

--- a/src/pyqula/transporttk/didv.py
+++ b/src/pyqula/transporttk/didv.py
@@ -76,10 +76,19 @@ def _lead_is_superconducting(h):
     return not h.get_anomalous_hamiltonian().is_zero()
 
 
+def _is_localprobe(ht):
+    from .localprobe import LocalProbe
+    return isinstance(ht,LocalProbe)
+
+
 def _both_leads_superconducting(ht):
     """Whether `ht` is a two-lead heterostructure (Heterostructure.Hl/Hr
-    set by heterostructures.build) with both leads superconducting -- the
-    case where the Floquet-Keldysh formalism applies."""
+    set by heterostructures.build) with both leads superconducting, or a
+    LocalProbe whose probe (`ht.lead`) and sample (`ht.H`) are both
+    superconducting -- the case where the Floquet-Keldysh formalism
+    applies."""
+    if _is_localprobe(ht):
+        return _lead_is_superconducting(ht.lead) and _lead_is_superconducting(ht.H)
     if not (hasattr(ht,"Hl") and hasattr(ht,"Hr")): return False
     return _lead_is_superconducting(ht.Hl) and _lead_is_superconducting(ht.Hr)
 
@@ -89,8 +98,11 @@ def keldysh_didv(ht,voltage=0.0,delta=1e-6,dv=None,**kwargs):
     obtained as a central finite-difference derivative of the
     Floquet-Keldysh DC current (Heterostructure.get_dc_current), see
     keldyshtk/current.py and San-Jose, Cayao, Prada, Aguado, NJP 15, 075019
-    (2013). Only supported for two-lead heterostructures with no explicit
-    central region (heterostructures.build(h1,h2))."""
+    (2013). Supported for two-lead heterostructures with no explicit
+    central region (heterostructures.build(h1,h2)), and for a LocalProbe
+    (transporttk.localprobe.LocalProbe) whose probe lead is itself
+    superconducting -- the probe and the sample site it couples to play
+    the role of the two leads."""
     from ..keldyshtk.current import dc_current
     if dv is None: dv = max(abs(voltage)*1e-2,1e-3)
     Ip = dc_current(ht,voltage+dv,delta=delta,**kwargs)
@@ -108,7 +120,8 @@ def didv(ht,energy=0.0,delta=1e-6,kwant=False,opl=None,opr=None,
         `ht.has_eh` is True).
       - "keldysh": Floquet-Keldysh dI/dV, see `keldysh_didv`. Only valid
         for a two-lead heterostructure with no explicit central region and
-        both leads superconducting.
+        both leads superconducting, or a LocalProbe with a superconducting
+        probe and sample.
       - "auto" (default): "keldysh" if both leads of `ht` are
         superconducting, otherwise "smatrix" -- this matches the physical
         case each method is built for (Keldysh MAR/Josephson physics needs

--- a/src/pyqula/transporttk/localprobe.py
+++ b/src/pyqula/transporttk/localprobe.py
@@ -49,6 +49,18 @@ class LocalProbe():
     def didv(self,T=None,**kwargs):
         from .didv import didv
         return didv(self,**kwargs)
+    def get_dc_current(self,voltage,**kwargs):
+        """Floquet-Keldysh DC current at bias `voltage` between the probe
+        and the sample site it couples to, see
+        Heterostructure.get_dc_current and keldyshtk/current.py. Only
+        meaningful (and only exact) when the probe lead is itself
+        superconducting -- see didv(method="keldysh")."""
+        from ..keldyshtk.current import dc_current
+        return dc_current(self,voltage,**kwargs)
+    def get_iv_curve(self,voltages,**kwargs):
+        """Floquet-Keldysh I(V) curve, see get_dc_current"""
+        from ..keldyshtk.current import iv_curve
+        return iv_curve(self,voltages,**kwargs)
     def copy(self): return deepcopy(self)
     def set_coupling(self,c):
         self.T = c # set the coupling

--- a/tests/keldysh/test_localprobe_keldysh.py
+++ b/tests/keldysh/test_localprobe_keldysh.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+from scipy.integrate import quad
+
+from pyqula import geometry
+from pyqula.transporttk.localprobe import LocalProbe
+from pyqula.operators import get_electron, get_hole
+
+
+def _tauz(h):
+    return np.array((get_electron(h)-get_hole(h)).todense())
+
+
+def test_auto_method_keeps_smatrix_when_probe_is_normal():
+    """A normal-metal probe on a superconducting sample (the setup used by
+    examples/transport/decay_constant) must keep using the existing
+    scattering-matrix/BdG formula -- Floquet-Keldysh only applies once the
+    probe lead itself carries a nonzero pairing amplitude."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(); h.shift_fermi(1.); h.add_swave(0.1)
+    lp = LocalProbe(h, delta=1e-8)
+    lp.T = 2e-2
+    Gauto = lp.didv(energy=0.05)
+    Gsmatrix = lp.didv(energy=0.05, method="smatrix")
+    assert Gauto == Gsmatrix
+
+
+def test_auto_method_routes_to_keldysh_when_probe_and_sample_are_superconducting():
+    """With both the probe lead and the sample superconducting, the default
+    ("auto") method must route through the Floquet-Keldysh dI/dV, matching
+    an explicit method="keldysh" call exactly (same code path)."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(); h.shift_fermi(1.); h.add_swave(0.1)
+    lead = geometry.chain().get_hamiltonian(); lead.shift_fermi(1.); lead.add_swave(0.1)
+    lp = LocalProbe(h, lead=lead, delta=1e-3)
+    lp.T = 0.3
+    kwargs = dict(nmax=4, nmax_max=10, tol=1e-2)
+    Gauto = lp.didv(energy=0.25, **kwargs)
+    Gkeldysh = lp.didv(energy=0.25, method="keldysh", **kwargs)
+    assert Gauto == Gkeldysh
+
+
+def test_keldysh_linear_response_matches_equilibrium_andreev_for_localprobe():
+    """For a LocalProbe with a normal (zero-pairing but Nambu) probe and a
+    superconducting sample, the zero-bias slope of the Floquet-Keldysh
+    current (LocalProbe.get_dc_current) must match the existing
+    equilibrium Andreev conductance (LocalProbe.didv, via
+    transporttk.didv.didv_BdG) -- the two are the same physical quantity
+    computed by independent code paths, exactly as already checked for a
+    two-lead Heterostructure in test_andreev_linear_response.py."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(); h.shift_fermi(1.); h.turn_nambu()
+    lead = geometry.chain().get_hamiltonian(has_spin=False); lead.turn_nambu()
+    delta = 0.3
+    h.add_swave(delta)
+    lp = LocalProbe(h, lead=lead, delta=1e-4)
+    lp.T = 0.5
+
+    Gref = lp.didv(energy=1e-4, method="smatrix")
+    dv = 0.02*delta
+    Gkeldysh = lp.didv(energy=0.0, method="keldysh", dv=dv,
+                        nmax=4, nmax_max=10, tol=1e-2)
+    assert abs(Gkeldysh-Gref) < 0.05*max(Gref, 1e-8)
+
+
+@pytest.mark.parametrize("voltage", [0.3, -0.3])
+def test_localprobe_normal_junction_matches_static_bias_reference(voltage):
+    """A LocalProbe between two plain (non-superconducting) leads, promoted
+    to trivial (zero-pairing) Nambu form so the Floquet-Keldysh machinery
+    applies, must reduce to ordinary (non-Floquet) biased Landauer
+    transport, exactly as already checked for a two-lead Heterostructure in
+    test_normal_junction_gauge_invariance.py: the DC current from
+    get_dc_current must match the current obtained by directly biasing the
+    probe and the sample and integrating the resulting static transmission
+    over the bias window."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(); h.shift_fermi(1.); h.turn_nambu()
+    lead = geometry.chain().get_hamiltonian(has_spin=False); lead.turn_nambu()
+    transparency = 0.4
+    lp = LocalProbe(h, lead=lead, delta=1e-4)
+    lp.T = transparency
+
+    Icalc = lp.get_dc_current(voltage, nmax=6, nmax_max=16, tol=1e-3)
+
+    tz_h = _tauz(h)
+    hb = h.copy(); hb.intra = hb.intra - (voltage/2)*tz_h
+    tz_l = _tauz(lead)
+    leadb = lead.copy(); leadb.intra = leadb.intra + (voltage/2)*tz_l
+    lpb = LocalProbe(hb, lead=leadb, delta=1e-4)
+    lpb.T = transparency
+    f = lambda e: lpb.didv(energy=e, method="smatrix")
+    Iref, _ = quad(f, -abs(voltage)/2, abs(voltage)/2, limit=100, epsrel=1e-5)
+    Iref *= np.sign(voltage)
+
+    assert abs(Icalc-Iref) < 2e-2*max(abs(Iref), 1e-8)
+
+
+def test_explicit_central_region_style_checks_still_apply():
+    """get_dc_current on a LocalProbe still requires a Nambu (BdG) sample,
+    just like the two-lead heterostructure case."""
+    g = geometry.chain()
+    h = g.get_hamiltonian()  # no turn_nambu(): has_eh is False
+    lp = LocalProbe(h, delta=1e-4)
+    with pytest.raises(NotImplementedError):
+        lp.get_dc_current(0.1)


### PR DESCRIPTION
## Summary
- `LocalProbe.didv`/`get_kappa` previously always used the scattering-matrix (BdG) formula, which breaks down once the probe tip itself carries a pairing amplitude (no normal lead left to define a reflection amplitude against). The Floquet-Keldysh MAR machinery (`keldyshtk/current.py`), so far only wired up for `heterostructures.build(h1,h2)`, now also accepts a `LocalProbe`: block 0 is the probe's unit cell, block 1 is the single bulk site being probed, coupled by `lp.T`.
- `didv(method="auto")` routes to `"keldysh"` whenever both the probe and the sample are superconducting, mirroring the existing two-lead `Heterostructure` convention. `LocalProbe` also gains `get_dc_current`/`get_iv_curve` for API parity.
- Added `examples/transport/decay_constant_keldysh/main.py`, based on `examples/transport/decay_constant` but with a superconducting STM tip, and documented the new capability in `documentation/user_guide.md` / `README.md`.

## Test plan
- [x] `pytest tests/keldysh` (33 pre-existing + 6 new tests) passes
- [x] Full `pytest tests` (253 tests) passes
- [x] New tests validate two independent-physics invariants against the existing smatrix/static-bias reference (zero-bias Andreev linear response, normal-junction gauge invariance), not just "it runs"
- [x] Ran `examples/transport/decay_constant_keldysh/main.py` end-to-end (headless/Agg backend) with no errors