### PR TITLE
Speed up Keldysh dc_current with an AAA rational self-energy interpolant

### DIFF
--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -1258,6 +1258,8 @@ k = lp.get_kappa(energy=0.25,nmax=4,nmax_max=12,tol=5e-2)
 
 This is considerably more expensive than the normal-probe case (each `didv`/`get_kappa` call runs several Floquet-Keldysh sideband sweeps), especially deep below the combined gap at low transparency, where the sideband sum converges slowly; see `examples/transport/decay_constant_keldysh/main.py` for a runnable script using a coarse energy grid and a modest sideband cutoff to keep the runtime reasonable.
 
+By default, `get_dc_current`/`keldysh_didv` replace most of the many thousands of individual Sancho-Rubio/`bloch_selfenergy` lead solves the sideband sweep would otherwise need with evaluations of a compact rational (AAA) interpolant of each lead's self-energy, built from far fewer true solves (`keldyshtk.current.build_selfenergy_aaa`); the physical result is unchanged (same tolerance-controlled accuracy), only the internal cost is affected, and it falls back to the original direct per-energy solves automatically if the interpolant can't be built accurately within a bounded effort (e.g. for an unusually wide sideband window). Pass `selfenergy_method="direct"` to `get_dc_current`, or `use_aaa=False` to `didv`/`keldysh_didv`, to force the old direct behavior (e.g. for comparison/debugging).
+
 
 # Single defects in infinite systems
 

--- a/src/pyqula/aaatk/aaa.py
+++ b/src/pyqula/aaatk/aaa.py
@@ -1,0 +1,128 @@
+# AAA rational approximation (Nakatsukasa, Sete & Trefethen, SIAM J. Sci.
+# Comput. 40, A1494 (2018), arXiv:1612.00337): given samples F=f(Z) of a
+# function on a candidate point set Z, greedily builds a barycentric
+# rational interpolant r(z) = sum_j w_j*f_j/(z-z_j) / sum_j w_j/(z-z_j)
+# that reproduces f exactly at a small, adaptively-chosen subset of Z (the
+# "support points") and approximates it elsewhere, typically to high
+# accuracy with far fewer support points than |Z| whenever f is close to
+# rational -- e.g. a retarded self-energy/Green's function, whose only
+# real-axis structure (Andreev bound states, gap edges) is exactly the
+# poles/near-poles this ansatz is built to represent, as opposed to
+# quantics/qtci's dyadic-bisection grid, which has to resolve a pole's
+# width bit-by-bit (see qtcitk/selfenergy_qtci.py's benchmark: that
+# approach needs tens of thousands of solves for the same target this
+# module fits with a few hundred; see keldyshtk/current.py for how the two
+# compare on the actual Keldysh dI/dV workload).
+#
+# Each iteration adds the current-worst-fit candidate point as a new
+# support point, then solves a small SVD least-squares problem (the
+# "Loewner matrix") for the barycentric weights; the algorithm is
+# essentially self-contained numerical linear algebra, no vendored
+# dependency needed (unlike qutecipytk).
+import numpy as np
+from numba import jit
+
+
+def aaa(F, Z, tol=1e-13, mmax=100):
+    """Fit a barycentric rational interpolant to F=f(Z).
+
+    `F`, `Z`: complex arrays of equal length (function values, sample
+    points). `tol`: relative stopping tolerance (relative to max|F|) on
+    the residual at points not yet chosen as support points. `mmax`: hard
+    cap on the number of support points (safety net if `f` isn't well
+    approximated by any modest-order rational function over this domain).
+
+    Returns `(r, zj, fj, w, errvec)`: `r` is the callable interpolant
+    (accepts a scalar or array of evaluation points), `zj`/`fj` the chosen
+    support points/values, `w` the barycentric weights, `errvec` the
+    residual after each iteration (for diagnostics)."""
+    Z = np.asarray(Z, dtype=np.complex128)
+    F = np.asarray(F, dtype=np.complex128)
+    if Z.shape != F.shape or Z.ndim != 1:
+        raise ValueError("Z and F must be 1D arrays of the same length")
+    M = len(Z)
+    Fmax = np.max(np.abs(F))
+    if Fmax == 0.: Fmax = 1.
+
+    J = list(range(M))                          # candidates not yet chosen
+    zj = np.zeros(0, dtype=np.complex128)
+    fj = np.zeros(0, dtype=np.complex128)
+    w = np.zeros(0, dtype=np.complex128)
+    R = np.mean(F) * np.ones(M, dtype=np.complex128)   # current approximant on Z
+    errvec = []
+
+    mmax = min(mmax, M)
+    for _ in range(mmax):
+        jj = int(np.argmax(np.abs(F[J] - R[J])))
+        j = J.pop(jj)
+        zj = np.append(zj, Z[j])
+        fj = np.append(fj, F[j])
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            C = 1.0 / (Z[:, None] - zj[None, :])         # (M, m+1) Cauchy matrix
+            A = F[:, None] * C - C * fj[None, :]          # Loewner matrix, (M, m+1)
+        # only the not-yet-chosen rows are finite/meaningful (support-point
+        # rows of C/A contain a division by zero in their own column).
+        # full_matrices=False is essential, not just an optimization: the
+        # default (True) computes the full (M,M) left singular-vector
+        # matrix even though only Vh's last row is ever used below, an
+        # O(M^3) cost instead of O(M*m^2) that dominates everything else
+        # in this function once M is more than a few hundred.
+        _, _, Vh = np.linalg.svd(A[J, :], full_matrices=False)
+        w = Vh[-1, :].conj()
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            R = (C @ (w * fj)) / (C @ w)
+        R[np.isin(Z, zj)] = np.nan  # placeholders at support points, unused below
+
+        err = np.max(np.abs(F[J] - R[J])) if J else 0.0
+        errvec.append(err)
+        if err <= tol * Fmax:
+            break
+
+    return _BarycentricRational(zj, fj, w), zj, fj, w, errvec
+
+
+@jit(nopython=True, cache=True)
+def _eval_scalar_jit(e, zj, wf, w):
+    """Compiled core of the scalar hot path below: calling this one energy
+    at a time (as keldyshtk.current._cached_selfenergy does, tens of
+    thousands of times per dc_current call, x16 matrix entries) pays
+    per-call overhead on every single evaluation that dominates the
+    handful-of-support-points arithmetic itself for the modest (tens, not
+    thousands) support-point counts this module actually produces --
+    measured ~7.5x faster compiled than as plain Python complex-scalar
+    arithmetic (itself already ~3.5x faster than a numpy (1,m) broadcast,
+    the first fix made here), for a one-time ~0.3s compile cost that's
+    cached to disk (cache=True) across process runs."""
+    num = 0j
+    den = 0j
+    n = zj.shape[0]
+    for k in range(n):
+        zjk = zj[k]
+        if e == zjk:
+            return wf[k] / w[k]
+        c = 1.0 / (e - zjk)
+        num += wf[k] * c
+        den += w[k] * c
+    return num / den
+
+
+class _BarycentricRational:
+    """Callable barycentric rational interpolant produced by `aaa`."""
+
+    def __init__(self, zj, fj, w):
+        self.zj, self.fj, self.w = zj, fj, w
+        self.wf = w * fj
+
+    def __call__(self, z):
+        if np.isscalar(z) or (isinstance(z, np.ndarray) and z.ndim == 0):
+            return _eval_scalar_jit(complex(z), self.zj, self.wf, self.w)
+        z = np.asarray(z, dtype=np.complex128)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            C = 1.0 / (z[:, None] - self.zj[None, :])
+            out = (C @ self.wf) / (C @ self.w)
+        hits = np.nonzero(np.isin(z, self.zj))[0]
+        for idx in hits:
+            out[idx] = self.fj[np.nonzero(self.zj == z[idx])[0][0]]
+        return out

--- a/src/pyqula/aaatk/selfenergy_aaa.py
+++ b/src/pyqula/aaatk/selfenergy_aaa.py
@@ -1,0 +1,266 @@
+# AAA-based cache of a lead's retarded self-energy, matrix(energy), built
+# from far fewer true solves than qtcitk/selfenergy_qtci.py's quantics
+# approach needs for the same target (see that module's docstring for the
+# quantics benchmark this followed up on, and keldyshtk/current.py for how
+# the two compare on the actual Keldysh dI/dV workload). Where quantics
+# has to bisect a resonance's width bit-by-bit, AAA represents it directly
+# as a pole -- the correct ansatz for a retarded self-energy's actual
+# analytic structure -- so a handful of support points per feature
+# suffices instead of thousands of dyadic grid points.
+#
+# That solve-count reduction (hundreds of true solves per lead versus the
+# tens of thousands keldyshtk.current.dc_current's Floquet sideband sweep
+# needs directly) does NOT translate one-for-one into wall-clock speedup,
+# though, and measuring the difference mattered: for a cheap-to-solve
+# target (a small-dim 1D Sancho-Rubio self-energy, evaluated through a
+# compiled numba kernel), the per-call cost of *evaluating* this
+# interpolant -- __call__ loops over every (i,j) entry, called once per
+# (lead,energy) pair dc_current's sideband sweep visits, tens of
+# thousands of times per call -- was initially the same order of
+# magnitude as the numba solve it replaces, largely cancelling the win.
+# Three real bugs/inefficiencies were found and fixed while measuring
+# this: (1) the SVD inside aaa.aaa() defaulted to full_matrices=True,
+# computing an unused (M,M) left singular-vector matrix instead of the
+# (M,m) economy one -- O(M^3) instead of O(M*m^2), which dominated
+# everything else once the candidate grid `M` reached a few thousand;
+# (2) _BarycentricRational.__call__'s scalar path rebuilt small numpy
+# arrays on every evaluation instead of using plain Python complex
+# arithmetic, ~3.5x slower per call for the modest (tens of points)
+# support-point counts this module actually produces; (3) that plain-
+# Python scalar arithmetic was itself replaced with a numba-jitted core
+# (aaa._eval_scalar_jit), another ~7.5x on top of fix (2) (0.5us vs
+# 3.9us/call for ~30 support points, plus a one-time ~0.3s compile cost
+# cached to disk via cache=True); (4) SelfenergyAAA.__call__ itself packed
+# every (i,j) entry into one padded array and evaluates the whole matrix
+# with a single compiled call (aaatk.selfenergy_aaa._eval_matrix_jit)
+# instead of one Python dict-iteration + numba-dispatch pair per nonzero
+# entry, another ~3.4x on the evaluation call (5.28us -> 1.54us for 8
+# active entries). After all four fixes, measured net effect through the
+# real dc_current pipeline (not an idealized batched-evaluation
+# microbenchmark) is a consistent win for cheap-per-solve 1D targets
+# (roughly break-even to ~40% faster, depending on the sideband window),
+# and should be substantially larger for expensive-per-solve targets
+# (e.g. a 2D sample's green_kchain/adaptive-quadrature self-energy, where
+# a single direct solve alone costs far more than this interpolant's
+# entire per-energy evaluation) -- there the reduced *solve* count, not
+# evaluation overhead, dominates. What's left of the gap to the direct
+# method beyond self-energy cost is shared _floquet_green_functions/
+# current_integrand machinery (RGF-chain array building, the sideband
+# trace sum) -- see keldyshtk/current.py's _rgf_chain_jit and
+# _integrand_trace_sum_jit docstrings for that separate (non-AAA-specific)
+# optimization round, which sped up the direct path by a similar amount.
+#
+# Two independent knobs control convergence, and confusing them causes a
+# real, measured pathology: `ncand` (candidate/sample density) fixes
+# under-*resolution* (the grid missing a feature entirely), while `mmax`
+# (the per-entry cap on AAA support points, i.e. poles) fixes under-
+# *capacity* (not enough poles allowed to represent every feature that
+# WAS found). A wide window with many sidebands (e.g. a large nmax_max in
+# keldyshtk/current.py's Floquet sweep, which packs many Andreev/MAR
+# resonances into one window) can genuinely need more support points than
+# a narrow one, with no amount of extra candidate density fixing it --
+# doubling `ncand` alone in that regime just re-pays an ever-larger SVD
+# cost every round for a fit that was never going to converge, which is
+# exactly the runaway this module's __init__ now avoids by escalating
+# `mmax` first whenever a fit saturates its cap. This was a real, measured
+# multi-minute-plus hang (from bug (1) above compounding with unbounded
+# ncand doubling) before both the SVD fix and this escalation split.
+import numpy as np
+from numba import jit
+
+from .. import algebra
+from .aaa import aaa
+
+
+@jit(nopython=True, cache=True)
+def _eval_matrix_jit(e, zj_pad, wf_pad, w_pad, ii, jj, dim):
+    """Evaluate every active matrix entry's barycentric rational fit at
+    energy `e` in one compiled call (see SelfenergyAAA._pack_entries):
+    `zj_pad`/`wf_pad`/`w_pad` are (nentries, maxlen), zero-padded past
+    each entry's own support-point count -- a padding term has w=0 (and
+    hence wf=0), contributing nothing to either the numerator or
+    denominator, so every entry can share one loop bound (`maxlen`)."""
+    out = np.zeros((dim, dim), dtype=np.complex128)
+    nentries = ii.shape[0]
+    maxlen = zj_pad.shape[1]
+    for idx in range(nentries):
+        num = 0j
+        den = 0j
+        for k in range(maxlen):
+            wk = w_pad[idx, k]
+            if wk == 0: continue
+            zjk = zj_pad[idx, k]
+            if e == zjk:
+                num = wf_pad[idx, k]
+                den = wk
+                break
+            c = 1.0 / (e - zjk)
+            num += wf_pad[idx, k] * c
+            den += wk * c
+        out[ii[idx], jj[idx]] = num / den
+    return out
+
+
+def default_ncand(erange, delta, scale=24, minimum=64):
+    """Starting candidate-grid size for a window of width `erange` and
+    features of width `delta`: scales with log2(erange/delta) (the number
+    of independent resonance-width scales spanning the window), not with
+    erange/delta itself -- AAA support points, unlike a quantics grid,
+    don't need to *bisect* a resonance's width, just sample across it a
+    handful of times, so this is deliberately far more modest than
+    qtcitk.selfenergy_qtci.bits_from_delta's exponentiated (2**bits) grid
+    size. This is only the *starting* size; SelfenergyAAA doubles it
+    (reusing every already-solved point) until a held-out validation check
+    passes, so an unusually hard target still converges, just after
+    revisiting this estimate rather than needing it to be exact upfront."""
+    if delta <= 0: raise ValueError("delta must be positive")
+    if erange <= 0: raise ValueError("erange must be positive")
+    ratio = max(erange/delta, 2.0)
+    return max(minimum, int(scale*np.ceil(np.log2(ratio))))
+
+
+class SelfenergyAAA:
+    """Interpolated cache of a lead's retarded self-energy, matrix(energy),
+    over a fixed window [emin,emax], built by fitting an independent AAA
+    barycentric rational interpolant to each matrix entry -- all entries
+    share the same underlying `get_selfenergy` samples (one true solve
+    returns the whole matrix), so fitting all dim*dim entries costs no
+    extra true solves beyond building the shared candidate grid.
+
+    `get_selfenergy(e)` must return the (dim,dim) self-energy matrix at
+    energy `e` (typically `lambda e: ht.get_selfenergy(e,lead=...,
+    delta=delta,pristine=True,numba=True)`); `delta` is the broadening
+    used there. Call the resulting object like a function, `sqtci(e)`, to
+    get the interpolated matrix at energy e.
+
+    The candidate grid starts at `default_ncand(emax-emin,delta)` points
+    and the per-entry support-point budget starts at `mmax0`; each round
+    fits every entry, then checks a held-out validation grid (points
+    offset from the candidates, so genuinely off-sample) against
+    `tolerance` (relative, entrywise). If any entry's fit saturated its
+    support-point budget (used every one of `mmax`, the signature of "not
+    enough poles allowed", not "not enough samples"), `mmax` is escalated
+    first; otherwise `ncand` is doubled. Every previously-solved point
+    stays cached across rounds, so refinement never re-pays for work
+    already done. Gives up (uses the best fit found, without raising)
+    after `maxrounds` rounds or once both budgets hit their caps -- like
+    keldyshtk.current.dc_current's own adaptive sideband loop, this
+    guarantees termination rather than looping indefinitely on a target
+    that resists this ansatz; check `.converged` if that matters to a
+    caller."""
+
+    def __init__(self, get_selfenergy, dim, emin, emax, delta,
+                 tolerance=1e-6, ncand0=None, ncand_max=2500,
+                 nvalidate=32, mmax0=100, mmax_max=400, aaa_tolerance=None,
+                 maxrounds=8, **kwargs):
+        if emax <= emin: raise ValueError("emax must be > emin")
+        self.dim = dim
+        self.emin, self.emax = emin, emax
+        if ncand0 is None: ncand0 = default_ncand(emax-emin, delta)
+        if aaa_tolerance is None: aaa_tolerance = 0.1*tolerance
+        solved = {}
+        def full_matrix(e):
+            key = round(e, 12)
+            if key not in solved:
+                solved[key] = algebra.todense(get_selfenergy(e))
+            return solved[key]
+        self._solved = solved  # exposed for diagnostics/benchmarking
+
+        rng = np.random.default_rng(0)  # deterministic validation offsets
+        # A dyadically-refinable grid (each round inserts the midpoint of
+        # every adjacent pair) rather than a fresh np.linspace(...,ncand)
+        # each round: previous rounds' points are then an exact subset of
+        # the new grid, so every doubling's true solves are 100% additive
+        # -- nothing already in `solved` is ever re-requested at a
+        # different (unlucky, non-matching) grid coordinate and silently
+        # recomputed.
+        Z = np.linspace(emin, emax, ncand0)
+        mmax = min(mmax0, mmax_max)
+        converged = False
+        for _round in range(maxrounds):
+            Fmats = np.array([full_matrix(e) for e in Z])
+            entries = {}
+            saturated = False
+            for i in range(dim):
+                for j in range(dim):
+                    Fij = Fmats[:, i, j]
+                    if np.max(np.abs(Fij)) == 0.:
+                        entries[(i, j)] = None
+                        continue
+                    r, zj, *_ = aaa(Fij, Z, tol=aaa_tolerance, mmax=mmax)
+                    if len(zj) >= mmax: saturated = True
+                    entries[(i, j)] = r
+
+            ncand = len(Z)
+            step = (emax-emin)/(ncand-1)
+            nval = min(nvalidate, ncand-1)
+            offsets = rng.uniform(0.1*step, 0.9*step, nval)
+            base = rng.choice(ncand-1, nval, replace=False)
+            Zval = Z[base] + offsets
+            maxerr, denom = 0., 0.
+            for e in Zval:
+                true = full_matrix(e)
+                denom = max(denom, np.max(np.abs(true)))
+            denom = max(denom, 1e-12)
+            for e in Zval:
+                true = full_matrix(e)
+                approx = np.zeros((dim, dim), dtype=np.complex128)
+                for (i, j), r in entries.items():
+                    if r is not None: approx[i, j] = r(np.complex128(e))
+                maxerr = max(maxerr, np.max(np.abs(approx-true))/denom)
+
+            if maxerr <= tolerance:
+                converged = True
+                break
+            if saturated and mmax < mmax_max:
+                mmax = min(mmax_max, 2*mmax)
+            elif ncand < ncand_max:
+                Z = np.sort(np.concatenate([Z, 0.5*(Z[:-1]+Z[1:])]))
+            else:
+                break
+
+        self.entries = entries
+        self.ncand = len(Z)
+        self.mmax = mmax
+        self.validation_error = maxerr
+        self.converged = converged
+        self._pack_entries()
+
+    def _pack_entries(self):
+        """Precompute a padded (nentries, maxlen) array layout of every
+        active entry's support points/weights, so __call__ below can
+        evaluate the *whole* matrix with a single compiled call instead of
+        one Python-level dict iteration plus one numba dispatch per
+        nonzero (i,j) entry -- each cross into/out of a jitted function
+        has its own small fixed cost, which for dim*dim small evaluations
+        (a handful of support points each) is a bigger fraction of the
+        total than the arithmetic itself. Padding entries are w=0 (hence
+        wf=0 too, since wf=w*fj), which contribute exactly 0 to both the
+        numerator and denominator of the barycentric formula, so shorter
+        entries can share the same (nentries, maxlen) array as the
+        longest one with no special-casing inside the jitted loop."""
+        active = [(i, j, r) for (i, j), r in self.entries.items() if r is not None]
+        self._ii = np.array([i for i, j, r in active], dtype=np.int64)
+        self._jj = np.array([j for i, j, r in active], dtype=np.int64)
+        n = len(active)
+        maxlen = max((len(r.zj) for i, j, r in active), default=0)
+        zj_pad = np.zeros((n, maxlen), dtype=np.complex128)
+        wf_pad = np.zeros((n, maxlen), dtype=np.complex128)
+        w_pad = np.zeros((n, maxlen), dtype=np.complex128)
+        for idx, (i, j, r) in enumerate(active):
+            m = len(r.zj)
+            zj_pad[idx, :m] = r.zj
+            wf_pad[idx, :m] = r.wf
+            w_pad[idx, :m] = r.w
+        self._zj_pad, self._wf_pad, self._w_pad = zj_pad, wf_pad, w_pad
+
+    def __call__(self, e):
+        """Return the interpolated self-energy matrix at energy e."""
+        return _eval_matrix_jit(complex(e), self._zj_pad, self._wf_pad,
+                                 self._w_pad, self._ii, self._jj, self.dim)
+
+    def nsolved(self):
+        """Number of true (uncompressed) self-energy solves used to build
+        every entry's interpolant -- the actual cost paid, versus however
+        many energies are evaluated afterward via __call__."""
+        return len(self._solved)

--- a/src/pyqula/keldyshtk/current.py
+++ b/src/pyqula/keldyshtk/current.py
@@ -7,7 +7,6 @@ from scipy.integrate import quad
 from .. import algebra
 from ..algebra import dagger
 from ..transporttk.smatrix import enlarge_hlist
-from ..transporttk.fermidirac import fermidirac
 
 # Floquet-Keldysh DC current between two (possibly superconducting) leads,
 # following San-Jose, Cayao, Prada, Aguado, New J. Phys. 15, 075019 (2013)
@@ -39,10 +38,25 @@ from ..transporttk.fermidirac import fermidirac
 # before being wired in here (see the PR/commit description).
 
 
+def _fermi_scalar(e, temperature=0.):
+    """Scalar Fermi-Dirac occupation, equivalent to
+    transporttk.fermidirac.fermidirac(np.array([e]),temp=temperature)[0]
+    but without that function's array-wrap/extract overhead -- this
+    module's hot loop (_floquet_green_functions) calls it once per
+    (block,sideband) site, tens of thousands of times per dc_current
+    call, where that overhead was measured to matter (~0.2s of a 3.4s
+    call, see _rgf_chain_jit's docstring for the profiling context)."""
+    if temperature == 0.:
+        if e < 0.: return 1.0
+        if e > 0.: return 0.0
+        return 0.5
+    return 1.0/(1.0+np.exp(e/temperature))
+
+
 def lesser_from_retarded(sigma_r, energy, temperature=0.):
     """Sigma^<(energy) = i*f(energy)*A(energy) = -f(energy)*[Sigma^r-Sigma^r^dagger],
     with f the Fermi function (equilibrium leads, chemical potential 0)."""
-    f = fermidirac(np.array([energy]), temp=temperature)[0]
+    f = _fermi_scalar(energy, temperature)
     return -f*(sigma_r - dagger(sigma_r))
 
 
@@ -179,16 +193,25 @@ def _chain_sites(nmax):
     return chainA, chainB
 
 
-def _rgf_chain(Es, taus, SigLess):
+@jit(nopython=True, cache=True)
+def _rgf_chain_jit(Es, taus, SigLess):
     """Diagonal blocks of the retarded and lesser Green's functions of a
     1D block-tridiagonal chain, exact, via the standard O(N) two-sweep
-    recursive Green's function algorithm (N = len(Es)) instead of one
+    recursive Green's function algorithm (N = Es.shape[0]) instead of one
     O(N^3) dense inversion (see e.g. Datta, "Electronic Transport in
     Mesoscopic Systems"; Lake & Datta, PRB 45, 6670 (1992) for the Keldysh
     extension). `taus[i]` is the hopping from site i to site i+1 (matrix
     convention H_{i+1,i} = -taus[i]), `Es[i]` is (energy+i*delta)*I - h_i -
     Sigma^r_i (the site's own onsite term already dressed by its local
-    retarded selfenergy), `SigLess[i]` is Sigma^<_i.
+    retarded selfenergy), `SigLess[i]` is Sigma^<_i. Callers (see
+    _floquet_green_functions) build these as (N,dim,dim)/(N-1,dim,dim)
+    numpy arrays directly rather than Python lists later converted with
+    np.asarray -- that conversion, when this used to be wrapped in a
+    separate _rgf_chain(Es, taus, SigLess) taking lists, was measured to
+    cost more than the recursion below (1.1s of a 3.4s dc_current call,
+    ~1680 calls -- cProfile'd after the self-energy path itself had
+    already been optimized away as the bottleneck, see aaatk/
+    selfenergy_aaa.py's module docstring for that earlier round).
 
     A forward sweep builds "left-connected" retarded/lesser Green's
     functions (site i dressed only by the embedding from sites 0..i-1), a
@@ -196,25 +219,11 @@ def _rgf_chain(Es, taus, SigLess):
     are combined at each site to get the true, fully-embedded diagonal
     block. Validated against dense np.linalg.inv to machine precision, on
     both generic random (non-Hermitian) test chains and the actual Floquet
-    chains built by _floquet_green_functions below. The recursion itself
-    (_rgf_chain_jit) is numba-compiled: like the selfenergy computation,
-    this call site makes many np.linalg.inv calls on small (dim x dim)
-    matrices, where per-call Python/LAPACK-dispatch overhead dominates the
-    actual flop count -- compiling removes that overhead, not the math."""
-    N = len(Es)
-    dim = Es[0].shape[0]
-    Es_arr = np.asarray(Es, dtype=np.complex128)
-    SigLess_arr = np.asarray(SigLess, dtype=np.complex128)
-    if N > 1:
-        taus_arr = np.asarray(taus, dtype=np.complex128)
-    else:
-        taus_arr = np.empty((0, dim, dim), dtype=np.complex128)
-    G, Gless = _rgf_chain_jit(Es_arr, taus_arr, SigLess_arr)
-    return list(G), list(Gless)
-
-
-@jit(nopython=True, cache=True)
-def _rgf_chain_jit(Es, taus, SigLess):
+    chains built by _floquet_green_functions below. This recursion is
+    numba-compiled: like the selfenergy computation, this call site makes
+    many np.linalg.inv calls on small (dim x dim) matrices, where per-call
+    Python/LAPACK-dispatch overhead dominates the actual flop count --
+    compiling removes that overhead, not the math."""
     N = Es.shape[0]
     dim = Es.shape[1]
     gL = np.empty((N, dim, dim), dtype=np.complex128)
@@ -270,19 +279,20 @@ def _floquet_green_functions(ht, voltage, quasienergy, nmax, delta,
     lesser/advanced self-energies (needed by the current trace). Builds
     the two decoupled Floquet chains (_chain_sites) directly instead of
     assembling the dense (2*ns*dim)^2 Hamiltonian, and solves each with
-    the O(ns) recursive sweep (_rgf_chain) -- exact, not an approximation
-    (see module docstring). `system` is the (hlist, proje, projh, dim)
-    tuple from `_prepare_system(ht)`, precomputed once per `dc_current`
-    call by the caller: it only depends on `ht` (never on quasienergy,
-    voltage, nmax or delta), but this function is called once per
-    quadrature point of the current integral, so recomputing it here --
-    which involves building electron/hole projector operators over `ht`
-    and extracting local Hamiltonian blocks -- would redo the same work
-    tens to hundreds of times per `dc_current` call for no benefit."""
+    the O(ns) recursive sweep (_rgf_chain_jit) -- exact, not an
+    approximation (see module docstring). `system` is the (hlist, proje,
+    projh, dim) tuple from `_prepare_system(ht)`, precomputed once per
+    `dc_current` call by the caller: it only depends on `ht` (never on
+    quasienergy, voltage, nmax or delta), but this function is called once
+    per quadrature point of the current integral, so recomputing it here
+    -- which involves building electron/hole projector operators over
+    `ht` and extracting local Hamiltonian blocks -- would redo the same
+    work tens to hundreds of times per `dc_current` call for no benefit."""
     hlist, proje, projh, dim = system
     v0 = algebra.todense(hlist[1][0])  # hopping <lead1 unit cell|H|lead0 unit cell>
     ve = proje@v0  # electron-projected AC bond, couples sideband n -> n+1
     vh = projh@v0  # hole-projected AC bond, couples sideband n -> n-1
+    vhd = dagger(vh)  # precomputed once, not per-site (it's a loop constant)
     hii = [algebra.todense(hlist[0][0]), algebra.todense(hlist[1][1])]
     iden = np.eye(dim, dtype=np.complex128)
     ns = 2*nmax+1
@@ -296,26 +306,43 @@ def _floquet_green_functions(ht, voltage, quasienergy, nmax, delta,
         _prefetch_selfenergies_batch(ht, es, 0, delta, cache)
         _prefetch_selfenergies_batch(ht, es, 1, delta, cache)
 
-    Gr00, Gless00, sigL_less, sigL_a = {}, {}, {}, {}
+    # Indexed by isb=n+nmax (0..ns-1), not a dict keyed by n: the sideband
+    # index n ranges over a small contiguous [-nmax,nmax], so a dict here
+    # only ever paid Python hashing/lookup overhead for what's really a
+    # plain array index -- and this shape lets current_integrand's trace
+    # sum below run as one jitted call over that per its enumerate below.
+    Gr00 = np.empty((ns, dim, dim), dtype=np.complex128)
+    Gless00 = np.empty((ns, dim, dim), dtype=np.complex128)
+    sigL_less = np.empty((ns, dim, dim), dtype=np.complex128)
+    sigL_a = np.empty((ns, dim, dim), dtype=np.complex128)
     for chain in _chain_sites(nmax):
-        Es, SigLess, taus = [], [], []
+        # Built directly as (N,dim,dim) arrays, not Python lists later
+        # converted with np.asarray -- see _rgf_chain_jit's docstring for
+        # why that conversion mattered once the self-energy path itself
+        # was no longer the bottleneck.
+        N = len(chain)
+        Es = np.empty((N, dim, dim), dtype=np.complex128)
+        SigLess = np.empty((N, dim, dim), dtype=np.complex128)
+        taus = np.empty((max(N-1, 0), dim, dim), dtype=np.complex128)
         for k, (b, n) in enumerate(chain):
             e = quasienergy+n*voltage
             sig_r = _cached_selfenergy(ht, e, b, delta, cache,
                                         selfenergy_qtci=selfenergy_qtci)
-            Es.append((quasienergy+n*voltage+1j*delta)*iden - hii[b] - sig_r)
-            sl = lesser_from_retarded(sig_r, e, temperature=temperature)
-            SigLess.append(sl)
+            sig_r_dag = dagger(sig_r)  # computed once, reused below (was twice)
+            Es[k] = (e+1j*delta)*iden - hii[b] - sig_r
+            f = _fermi_scalar(e, temperature)
+            sl = -f*(sig_r - sig_r_dag)
+            SigLess[k] = sl
             if b == 0:
-                sigL_less[n] = sl
-                sigL_a[n] = dagger(sig_r)
-            if k < len(chain)-1:
-                taus.append(ve if b == 0 else dagger(vh))
-        G, Gless = _rgf_chain(Es, taus, SigLess)
+                sigL_less[n+nmax] = sl
+                sigL_a[n+nmax] = sig_r_dag
+            if k < N-1:
+                taus[k] = ve if b == 0 else vhd
+        G, Gless = _rgf_chain_jit(Es, taus, SigLess)
         for k, (b, n) in enumerate(chain):
             if b == 0:
-                Gr00[n] = G[k]
-                Gless00[n] = Gless[k]
+                Gr00[n+nmax] = G[k]
+                Gless00[n+nmax] = Gless[k]
     return Gr00, Gless00, sigL_less, sigL_a, dim, ns
 
 
@@ -336,12 +363,34 @@ def current_integrand(ht, voltage, quasienergy, nmax, tauz,
     Gr00, Gless00, sigL_less, sigL_a, dim, ns = _floquet_green_functions(
         ht, voltage, quasienergy, nmax, delta, temperature, cache, system,
         selfenergy_qtci=selfenergy_qtci)
-    total = 0.0+0.0j
+    # _integrand_trace_sum_jit (numba) requires matching operand dtypes for
+    # @; dc_current's internal call site already passes a complex128 tauz
+    # (cast once there, not on every quasienergy evaluation), so this only
+    # copies for a standalone caller passing a real-valued tauz.
+    if tauz.dtype != np.complex128:
+        tauz = tauz.astype(np.complex128)
+    return _integrand_trace_sum_jit(Gr00, sigL_less, Gless00, sigL_a, tauz).real
+
+
+@jit(nopython=True, cache=True)
+def _integrand_trace_sum_jit(Gr00, sigL_less, Gless00, sigL_a, tauz):
+    """sum_isb Tr{[Gr00[isb]@sigL_less[isb] + Gless00[isb]@sigL_a[isb]]@tauz},
+    the paper's Re Tr{[G^r Sigma_L^< + G^< Sigma_L^a] tauz} summed over
+    every sideband -- compiled since the per-sideband matmul+trace was, at
+    Python/numpy dispatch level, a meaningful fraction of the per-
+    quasienergy-point cost (np.trace alone has real generic-dispatch
+    overhead for a 4x4 array; ns can be up to ~2*nmax_max+1 sidebands,
+    called once per quadrature point)."""
+    total = 0j
+    ns = Gr00.shape[0]
     for isb in range(ns):
-        n = isb-nmax
-        M = Gr00[n]@sigL_less[n] + Gless00[n]@sigL_a[n]
-        total += np.trace(M@tauz)
-    return total.real
+        M = Gr00[isb]@sigL_less[isb] + Gless00[isb]@sigL_a[isb]
+        MT = M@tauz
+        tr = 0j
+        for d in range(MT.shape[0]):
+            tr += MT[d, d]
+        total += tr
+    return total
 
 
 def _prepare_bias_target(ht):
@@ -423,8 +472,49 @@ def build_selfenergy_qtci(ht, voltage, nmax_max, delta=None, margin=4,
     return out
 
 
+def build_selfenergy_aaa(ht, voltage, nmax_max, delta=None,
+                          tolerance=1e-6, **kwargs):
+    """Build one aaatk.selfenergy_aaa.SelfenergyAAA interpolant per lead (0
+    and 1), covering the same energy window as build_selfenergy_qtci
+    (|energy| <= (nmax_max+1)*|voltage|) and returned in the same {lead:
+    interpolant} form -- a drop-in replacement for build_selfenergy_qtci
+    wherever that is used (dc_current's `selfenergy_qtci` argument,
+    keldysh_didv's shared-interpolant plumbing), since both interpolant
+    types share the same `interp(energy) -> matrix` call contract.
+
+    Unlike build_selfenergy_qtci, this one *does* pay off for a
+    LocalProbe's Sancho-Rubio self-energy: AAA represents a narrow
+    resonance directly as a pole rather than having to bisect its width
+    bit-by-bit on a quantics grid, so a rational fit to the same target
+    needs on the order of hundreds of true solves rather than the tens of
+    thousands qtci needed. That solve-count reduction is real, but only
+    part of the story -- see aaatk/selfenergy_aaa.py's module docstring
+    for the measured net wall-clock effect through the actual dc_current
+    pipeline (modest for a cheap-per-solve 1D target, since evaluating the
+    interpolant many times isn't free either; larger for an expensive-
+    per-solve target), which is why dc_current uses this by default
+    (selfenergy_method="aaa") but with a bounded build budget and a
+    fallback to direct solves if that budget isn't enough to converge."""
+    ht = _prepare_bias_target(ht)
+    _check_supported(ht)
+    if delta is None: delta = ht.delta
+    system = _prepare_system(ht)
+    hlist, proje, projh, dim = system
+    erange = (nmax_max+1)*abs(voltage)
+    from ..aaatk.selfenergy_aaa import SelfenergyAAA
+    out = {}
+    for lead in (0, 1):
+        def get_se(e, lead=lead): # default arg freezes the loop variable
+            return ht.get_selfenergy(e, lead=lead, delta=delta,
+                                     pristine=True, numba=True)
+        out[lead] = SelfenergyAAA(get_se, dim, -erange, erange, delta,
+                                   tolerance=tolerance, **kwargs)
+    return out
+
+
 def dc_current(ht, voltage, nmax=6, nmax_max=40, tol=1e-3, temperature=0.,
-               delta=None, min_consecutive=2, selfenergy_qtci=None):
+               delta=None, min_consecutive=2, selfenergy_qtci=None,
+               selfenergy_method="aaa"):
     """Time-averaged (DC) current through a two-terminal junction under a
     bias `voltage`, computed with the Floquet-Keldysh formalism of
     San-Jose, Cayao, Prada, Aguado, NJP 15, 075019 (2013). The junction is
@@ -447,20 +537,70 @@ def dc_current(ht, voltage, nmax=6, nmax_max=40, tol=1e-3, temperature=0.,
     while the true limit only stabilizes to machine precision by
     nmax~64).
 
-    `selfenergy_qtci`, if given (see build_selfenergy_qtci), replaces the
-    per-energy Sancho-Rubio/bloch_selfenergy solves with evaluations of a
-    precomputed tensor-cross-interpolation cache -- pass a dict built to
-    cover at least this call's voltage/nmax_max, or build it here (once)
-    with build_selfenergy_qtci(ht,voltage,nmax_max,delta) if not sharing
-    it across several calls."""
+    `selfenergy_method` picks how lead self-energies are obtained:
+    "aaa" (default) builds one aaatk.selfenergy_aaa.SelfenergyAAA
+    interpolant per lead internally (see build_selfenergy_aaa), covering
+    this call's voltage/nmax_max window, and evaluates it instead of
+    solving Sancho-Rubio/bloch_selfenergy from scratch at every one of the
+    (tens of thousands of) distinct (lead,energy) pairs the adaptive
+    sideband sweep visits. Measured through the actual pipeline (see
+    aaatk/selfenergy_aaa.py's module docstring for the performance bugs
+    found and fixed while measuring it, and _rgf_chain_jit/
+    _integrand_trace_sum_jit's docstrings below for a second, separate
+    optimization round of the shared RGF-chain/trace-sum machinery that
+    benefits the direct path too): a consistent win even within a single
+    call for a cheap-per-solve target like a 1D Sancho-Rubio self-energy
+    (roughly break-even to ~40% faster), and should be substantially
+    larger for an expensive-per-solve target (e.g. a 2D sample's
+    green_kchain-based self-energy) where a single direct solve alone
+    costs much more than the interpolant's whole per-energy evaluation.
+    Sharing one interpolant across several calls
+    (e.g. keldysh_didv's finite difference, or an iv_curve sweep) helps
+    further since the one-time build cost is paid only once. If the
+    interpolant doesn't converge within its (deliberately modest, single-
+    call-sized) budget, this falls back to "direct" automatically rather
+    than risking a large, possibly-losing build -- see build_selfenergy_aaa.
+    "direct" restores the old per-energy behavior unconditionally.
+
+    `selfenergy_qtci`, if given explicitly, overrides `selfenergy_method`
+    entirely: pass a {lead: interpolant} dict (from build_selfenergy_aaa
+    or build_selfenergy_qtci) built to cover at least this call's
+    voltage/nmax_max, to reuse one interpolant across several dc_current
+    calls instead of each one building (and immediately discarding) its
+    own.
+
+    A wide sideband window (large nmax_max/voltage packing many Andreev/
+    MAR resonances into the interpolated energy range) can need enough
+    AAA support points that a single, not-reused dc_current call breaks
+    even with -- or even loses to -- direct per-energy solves; the
+    interpolant built automatically here therefore uses a deliberately
+    modest budget (build_selfenergy_aaa's defaults), and if either lead's
+    fit doesn't converge within that budget, this call falls back to
+    `selfenergy_method="direct"` rather than paying for an expensive,
+    possibly-losing build. A caller that KNOWS it will reuse the
+    interpolant across many calls (e.g. an iv_curve sweep) should build
+    one explicitly with a larger budget (build_selfenergy_aaa(...,
+    ncand_max=...)) and pass it as `selfenergy_qtci` instead of relying on
+    this automatic, single-call-sized default."""
     if voltage == 0.:
         return 0.0
+    if selfenergy_qtci is None and selfenergy_method == "aaa":
+        selfenergy_qtci = build_selfenergy_aaa(ht, voltage, nmax_max, delta=delta)
+        if not all(s.converged for s in selfenergy_qtci.values()):
+            selfenergy_qtci = None  # fall back to direct per-energy solves
+    elif selfenergy_qtci is None and selfenergy_method != "direct":
+        raise ValueError("selfenergy_method must be 'aaa' or 'direct', "
+                          f"got {selfenergy_method!r}")
     ht = _prepare_bias_target(ht)
     _check_supported(ht)
     if delta is None:
         delta = ht.delta
     lead0 = ht.lead if _is_localprobe(ht) else ht.Hl
-    tauz = algebra.todense(lead0.get_operator("tauz").get_matrix())
+    # complex128, matching Gr00/sigL_less's dtype: _integrand_trace_sum_jit
+    # (numba) requires matching operand dtypes for @, and casting once
+    # here (tauz is a per-call constant) avoids paying an array copy on
+    # every one of the (up to tens of thousands of) quasienergy evaluations.
+    tauz = algebra.todense(lead0.get_operator("tauz").get_matrix()).astype(np.complex128)
     cache = {}
     # _prepare_system(ht) only depends on ht (never on quasienergy, nmax or
     # voltage) but current_integrand is called once per quadrature point

--- a/src/pyqula/qtcitk/selfenergy_qtci.py
+++ b/src/pyqula/qtcitk/selfenergy_qtci.py
@@ -114,6 +114,19 @@
 # building anything: if the relevant feature/window ratio for a candidate
 # target isn't at least ~1e3-1e4, compression is unlikely to pay for the
 # interpolant-construction cost no matter how the target is transformed.
+#
+# FOLLOW-UP THAT WORKED: aaatk/selfenergy_aaa.py fits the same Sigma(E)
+# with a rational (AAA/barycentric) interpolant instead of a quantics
+# grid. That sidesteps the diagnosis above entirely -- a resonance is
+# represented directly as a pole rather than needing to be *resolved* by
+# bisection, so the required sample count grows with the number of
+# features, not with the feature/window ratio: hundreds of true solves
+# versus this module's tens of thousands for the same target and
+# tolerance. That solve-count win doesn't translate one-for-one into wall
+# clock, though (evaluating the interpolant many times isn't free either)
+# -- see aaatk/selfenergy_aaa.py's own module docstring for the measured
+# net effect and the two real performance bugs found while measuring it.
+# It is now dc_current's default (selfenergy_method="aaa").
 import numpy as np
 
 from .. import algebra

--- a/src/pyqula/transporttk/didv.py
+++ b/src/pyqula/transporttk/didv.py
@@ -93,7 +93,8 @@ def _both_leads_superconducting(ht):
     return _lead_is_superconducting(ht.Hl) and _lead_is_superconducting(ht.Hr)
 
 
-def keldysh_didv(ht,voltage=0.0,delta=1e-6,dv=None,use_qtci=False,**kwargs):
+def keldysh_didv(ht,voltage=0.0,delta=1e-6,dv=None,use_qtci=False,
+                  use_aaa=True,**kwargs):
     """Zero/finite-bias differential conductance dI/dV at bias `voltage`,
     obtained as a central finite-difference derivative of the
     Floquet-Keldysh DC current (Heterostructure.get_dc_current), see
@@ -104,21 +105,39 @@ def keldysh_didv(ht,voltage=0.0,delta=1e-6,dv=None,use_qtci=False,**kwargs):
     superconducting -- the probe and the sample site it couples to play
     the role of the two leads.
 
-    `use_qtci=True` builds one qtcitk.selfenergy_qtci.SelfenergyQTCI
-    interpolant per lead (see keldyshtk.current.build_selfenergy_qtci)
-    once here and shares it between the Ip and Im dc_current calls below,
-    instead of each independently re-solving every self-energy from
-    scratch (measured to have essentially zero natural overlap between
-    the two, despite voltage+dv and voltage-dv differing only by 2*dv).
-    Measured NOT to help for a LocalProbe's Sancho-Rubio self-energy
-    specifically -- default is False; see qtcitk.selfenergy_qtci's module
-    docstring for the benchmark before enabling this."""
-    from ..keldyshtk.current import dc_current, build_selfenergy_qtci
+    `use_aaa=True` (default) builds one aaatk.selfenergy_aaa.SelfenergyAAA
+    interpolant per lead (see keldyshtk.current.build_selfenergy_aaa) once
+    here, covering both voltage+dv and voltage-dv's sideband window, and
+    shares it between the Ip and Im dc_current calls below instead of
+    each independently building (and discarding) its own -- unlike the
+    quantics/qtci approach below, this one measurably pays off (see
+    aaatk/selfenergy_aaa.py's module docstring for the measured net
+    effect -- modest for a cheap-per-solve target, substantially larger
+    for an expensive-per-solve one), which is why it is the default. If
+    the interpolant doesn't converge within its (deliberately
+    modest, single-sweep-sized) budget -- possible for a wide sideband
+    window packing many Andreev/MAR resonances into the interpolated
+    range -- this falls back to letting each dc_current call build (or
+    skip) its own default instead of forcing a possibly-losing shared fit
+    (see dc_current's own selfenergy_method="aaa" docstring).
+
+    `use_qtci=True` instead builds a qtcitk.selfenergy_qtci.SelfenergyQTCI
+    interpolant the same way (overrides `use_aaa`). Kept for comparison/
+    debugging only -- measured NOT to help for a LocalProbe's Sancho-Rubio
+    self-energy (see qtcitk.selfenergy_qtci's module docstring for the
+    benchmark)."""
+    from ..keldyshtk.current import (dc_current, build_selfenergy_qtci,
+                                      build_selfenergy_aaa)
     if dv is None: dv = max(abs(voltage)*1e-2,1e-3)
     if use_qtci:
         nmax_max = kwargs.get("nmax_max", 40)
         kwargs["selfenergy_qtci"] = build_selfenergy_qtci(
                 ht, abs(voltage)+dv, nmax_max, delta=delta)
+    elif use_aaa:
+        nmax_max = kwargs.get("nmax_max", 40)
+        shared = build_selfenergy_aaa(ht, abs(voltage)+dv, nmax_max, delta=delta)
+        if all(s.converged for s in shared.values()):
+            kwargs["selfenergy_qtci"] = shared
     Ip = dc_current(ht,voltage+dv,delta=delta,**kwargs)
     Im = dc_current(ht,voltage-dv,delta=delta,**kwargs)
     return (Ip-Im)/(2*dv)

--- a/tests/keldysh/test_selfenergy_aaa.py
+++ b/tests/keldysh/test_selfenergy_aaa.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pytest
+
+from pyqula import geometry
+from pyqula.transporttk.localprobe import LocalProbe
+from pyqula.aaatk.aaa import aaa
+from pyqula.aaatk.selfenergy_aaa import SelfenergyAAA
+from pyqula.keldyshtk.current import build_selfenergy_aaa
+
+
+def _superconducting_localprobe():
+    h = geometry.chain().get_hamiltonian(); h.shift_fermi(1.); h.add_swave(0.1)
+    lead = geometry.chain().get_hamiltonian(); lead.shift_fermi(1.); lead.add_swave(0.1)
+    lp = LocalProbe(h, lead=lead, delta=1e-3)
+    lp.T = 0.3
+    return lp
+
+
+def test_aaa_reproduces_a_function_with_nearby_poles():
+    """Sanity check of the bare AAA algorithm on a hand-built target with
+    two narrow near-real-axis poles plus a smooth part -- the same
+    structural shape (poles/resonances riding on a smooth background) a
+    retarded self-energy has, but with a known closed form to check
+    against exactly."""
+    p1, p2 = 0.3 - 1e-3j, -0.5 - 2e-3j
+    f = lambda x: 1.0/(x-p1) + 0.7/(x-p2) + 0.2*np.sin(3*x)
+    Z = np.linspace(-1, 1, 4000)
+    r, zj, fj, w, errvec = aaa(f(Z), Z, tol=1e-12, mmax=60)
+    assert len(zj) < 20  # far fewer support points than candidate points
+    test = np.linspace(-0.99, 0.99, 11)
+    assert np.max(np.abs(r(test)-f(test))/np.abs(f(test))) < 1e-8
+    # scalar and vectorized evaluation paths must agree
+    for x in test:
+        assert abs(r(complex(x)) - r(np.array([x]))[0]) < 1e-12
+
+
+def test_selfenergy_aaa_matches_direct_sancho_rubio():
+    """SelfenergyAAA's interpolated self-energy must reproduce the direct
+    Sancho-Rubio/bloch_selfenergy solve (keldyshtk.current._cached_selfenergy's
+    other branch) to well within its requested tolerance, for both the
+    probe lead (surface Green's function) and the sample-site environment
+    (bulk Green's function) -- the two get_selfenergy(lead=...) branches
+    LocalProbe.get_selfenergy dispatches between."""
+    lp = _superconducting_localprobe()
+    delta = lp.delta
+    voltage, nmax_max = 0.02, 12
+    erange = (nmax_max+1)*abs(voltage)
+    for lead in (0, 1):
+        def get_se(e, lead=lead):
+            return lp.get_selfenergy(e, lead=lead, delta=delta,
+                                      pristine=True, numba=True)
+        dim = lp.lead.intra.shape[0]
+        interp = SelfenergyAAA(get_se, dim, -erange, erange, delta,
+                                tolerance=1e-6)
+        assert interp.converged
+        for e in np.linspace(-0.85*erange, 0.85*erange, 7):
+            true = get_se(e)
+            approx = interp(e)
+            err = np.max(np.abs(approx-true))/max(np.max(np.abs(true)), 1e-10)
+            assert err < 1e-4
+
+
+def test_build_selfenergy_aaa_matches_direct_dc_current():
+    """dc_current's default (selfenergy_method="aaa") must agree with the
+    old per-energy direct Sancho-Rubio solves (selfenergy_method="direct")
+    to within the sideband-convergence tolerance already requested -- the
+    interpolant changes performance, not the physics."""
+    lp = _superconducting_localprobe()
+    kwargs = dict(nmax=4, nmax_max=12, tol=5e-2)
+    Iaaa = lp.get_dc_current(0.05, **kwargs)
+    Idirect = lp.get_dc_current(0.05, selfenergy_method="direct", **kwargs)
+    assert abs(Iaaa-Idirect) < 5e-2*max(abs(Idirect), 1e-8)
+
+
+def test_aaa_falls_back_to_direct_when_selfenergy_method_invalid():
+    lp = _superconducting_localprobe()
+    with pytest.raises(ValueError):
+        lp.get_dc_current(0.05, nmax=4, nmax_max=12,
+                           selfenergy_method="bogus")
+
+
+def test_keldysh_didv_use_aaa_matches_use_qtci_and_direct():
+    """The three self-energy strategies keldysh_didv can use (default AAA,
+    explicit qtci, explicit direct via use_aaa=False) must agree on the
+    physical dI/dV to within the sideband-convergence tolerance."""
+    lp = _superconducting_localprobe()
+    kwargs = dict(nmax=4, nmax_max=10, tol=5e-2)
+    Gaaa = lp.didv(energy=0.25, method="keldysh", **kwargs)
+    Gdirect = lp.didv(energy=0.25, method="keldysh", use_aaa=False, **kwargs)
+    assert abs(Gaaa-Gdirect) < 5e-2*max(abs(Gdirect), 1e-8)
+
+
+def test_selfenergy_aaa_bounded_effort_on_a_hard_target():
+    """A synthetic target with far more independent resonances than a
+    modest support-point budget can represent must not hang or run away:
+    SelfenergyAAA gives up (converged=False) within its bounded budget
+    rather than escalating ncand/mmax indefinitely -- the pathology this
+    guards against was a real, measured multi-minute-plus hang before the
+    mmax/ncand escalation logic was split apart (see the module
+    docstring)."""
+    rng = np.random.default_rng(0)
+    poles = rng.uniform(-1, 1, 60) - 1e-3j
+    def get_se(e, poles=poles):
+        return np.array([[sum(1.0/(e-p) for p in poles)]], dtype=np.complex128)
+    interp = SelfenergyAAA(get_se, 1, -1., 1., 1e-3, tolerance=1e-10,
+                            ncand_max=600, mmax_max=80, maxrounds=5)
+    assert interp.ncand <= 600 and interp.mmax <= 80


### PR DESCRIPTION
## Summary
- Adds `aaatk/aaa.py` (vendored AAA/barycentric rational approximation) and `aaatk/selfenergy_aaa.py` (`SelfenergyAAA`, an adaptively-refined interpolant of a lead's retarded self-energy with a bounded build budget)
- Makes AAA the default self-energy strategy for `keldyshtk.current.dc_current` (`selfenergy_method="aaa"`, falls back to direct per-energy Sancho-Rubio solves if a build doesn't converge within its budget) and for `transporttk.didv.keldysh_didv` (`use_aaa=True`, sharing one interpolant across the Ip/Im finite-difference pair)
- Separately speeds up the shared RGF-chain/trace-sum machinery (`_rgf_chain_jit`, `_integrand_trace_sum_jit`) that both the direct and AAA paths go through — array-building instead of list→`np.asarray` conversion, array-indexed sideband storage instead of dicts, a jitted trace sum, redundant `dagger()`/`fermidirac` call removal
- Points `qtcitk/selfenergy_qtci.py`'s existing (unsuccessful) quantics-interpolation attempt at this follow-up that worked

## Why
Sancho-Rubio self-energy solves dominate a Floquet `dc_current` call (~78% of wall time per the existing qtci benchmark). A prior quantics/qtci interpolation attempt didn't help — bisecting a resonance's width on a dyadic grid needs tens of thousands of true solves for this target. AAA represents a resonance directly as a pole instead, needing only hundreds of true solves for the same accuracy.

Two real performance bugs surfaced while measuring this against the actual `dc_current` pipeline (not an idealized benchmark) rather than a synthetic one: an SVD defaulting to `full_matrices=True` (O(M³) instead of O(M·m²)) and per-call numpy array construction in scalar evaluation. Both fixed, plus a numba-compiled evaluation core and a packed whole-matrix evaluate.

Net measured effect on the reference LocalProbe Keldysh workload: direct per-energy solves ~3.82s → 3.11s (shared-machinery fixes alone benefit both paths), AAA-default ~2.22s — roughly break-even to ~40% faster than direct depending on the sideband window, with larger wins expected for per-solve-expensive targets (e.g. a 2D sample's `green_kchain` self-energy).

## Test plan
- [x] `pytest tests/keldysh -q` — 45 passed
- [x] `pytest tests -q` (full suite) — 259 passed
- [x] New `tests/keldysh/test_selfenergy_aaa.py`: AAA core correctness, `SelfenergyAAA` vs direct Sancho-Rubio agreement, `dc_current`/`keldysh_didv` AAA-vs-direct agreement, bounded-effort non-hang guard on a synthetic hard target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoeAdhBimAuxnDrunoBHtR