### PR TITLE
keldysh_didv: don't clobber a caller-supplied selfenergy_qtci

### DIFF
--- a/src/pyqula/transporttk/didv.py
+++ b/src/pyqula/transporttk/didv.py
@@ -129,15 +129,20 @@ def keldysh_didv(ht,voltage=0.0,delta=1e-6,dv=None,use_qtci=False,
     from ..keldyshtk.current import (dc_current, build_selfenergy_qtci,
                                       build_selfenergy_aaa)
     if dv is None: dv = max(abs(voltage)*1e-2,1e-3)
-    if use_qtci:
-        nmax_max = kwargs.get("nmax_max", 40)
-        kwargs["selfenergy_qtci"] = build_selfenergy_qtci(
-                ht, abs(voltage)+dv, nmax_max, delta=delta)
-    elif use_aaa:
-        nmax_max = kwargs.get("nmax_max", 40)
-        shared = build_selfenergy_aaa(ht, abs(voltage)+dv, nmax_max, delta=delta)
-        if all(s.converged for s in shared.values()):
-            kwargs["selfenergy_qtci"] = shared
+    # Only auto-build a shared interpolant if the caller hasn't already
+    # passed their own selfenergy_qtci -- otherwise this would silently
+    # discard it in favor of a freshly built one every time, defeating the
+    # explicit-override escape hatch documented above and in dc_current.
+    if "selfenergy_qtci" not in kwargs:
+        if use_qtci:
+            nmax_max = kwargs.get("nmax_max", 40)
+            kwargs["selfenergy_qtci"] = build_selfenergy_qtci(
+                    ht, abs(voltage)+dv, nmax_max, delta=delta)
+        elif use_aaa:
+            nmax_max = kwargs.get("nmax_max", 40)
+            shared = build_selfenergy_aaa(ht, abs(voltage)+dv, nmax_max, delta=delta)
+            if all(s.converged for s in shared.values()):
+                kwargs["selfenergy_qtci"] = shared
     Ip = dc_current(ht,voltage+dv,delta=delta,**kwargs)
     Im = dc_current(ht,voltage-dv,delta=delta,**kwargs)
     return (Ip-Im)/(2*dv)


### PR DESCRIPTION
## Summary
Code review of #35 flagged that `keldysh_didv`'s default `use_aaa=True` path unconditionally overwrote `kwargs["selfenergy_qtci"]` with a freshly auto-built interpolant whenever it converged — even when the caller had already passed their own (e.g. following `dc_current`'s own documented pattern: build one explicitly with a larger budget and reuse it across calls). The same latent issue existed in the `use_qtci` branch above it, but `use_aaa` defaulting to `True` turned it into a bug hitting every default-path caller.

- Both auto-build branches (`use_qtci` and `use_aaa`) now skip building/overwriting when `selfenergy_qtci` is already present in `kwargs`, honoring an explicit override as `dc_current`'s own docstring says it should be.

## Test plan
- [x] Wrote a targeted check: monkeypatched `dc_current` on a superconducting `LocalProbe`, called `keldysh_didv` with an explicit `selfenergy_qtci`, and confirmed both the Ip and Im calls receive the exact caller-supplied instance (not a freshly built one) — this reproduces and confirms the fix for the exact scenario the review found.
- [x] `tests/keldysh`: 45 passed.
- [x] Full suite: 259 passed, no regressions.

https://claude.ai/code/session_01FoeAdhBimAuxnDrunoBHtR