### PR TITLE
sculpt/supercell: fix quadratic Python loops behind island cleaning and twisted-multilayer builders

### DIFF
--- a/src/pyqula/sculpt.py
+++ b/src/pyqula/sculpt.py
@@ -2,9 +2,7 @@ from __future__ import print_function
 from . import geometry
 from copy import deepcopy
 from . import algebra
-from numba import jit
 import numpy as np
-from . import algebra
 
 
 try: 
@@ -15,13 +13,13 @@ except: use_fortran = False
 
 def remove(g,l):
   """ Remove certain atoms from the geometry"""
-  nr = len(l) # number of removed atoms
+  lset = set(l) # membership test below is O(1) against a set, O(len(l)) against a list
   go = g.copy() # copy the geometry
   xo = [] # copy the list
   yo = [] # copy the list
   zo = [] # copy the list
   for i in range(len(g.x)):
-    if not i in l:
+    if not i in lset:
       xo.append(g.x[i])
       yo.append(g.y[i])
       zo.append(g.z[i])
@@ -38,7 +36,7 @@ def remove(g,l):
   if g.has_sublattice: # if has sublattice, keep the indexes
     ab = [] # initialize
     for i in range(len(g.x)):
-      if not i in l:
+      if not i in lset:
         ab.append(g.sublattice[i]) # keep the index
     go.sublattice = ab # store the keeped atoms
   return go
@@ -145,14 +143,17 @@ def remove_unibonded(g,d=1.0,tol=0.01,use_fortran=use_fortran,iterative=False):
       if not retain[i]: sb.append(i) # remove
     gout = remove(g,sb) # remove those atoms
   else: # use python routine
-    for i in range(len(g.r)): 
+    # precompute every direction's replicas once (this used to be redone
+    # from scratch inside the loop over i, turning what should be a single
+    # O(natoms) pass into an O(natoms^2) one) and count neighbors with
+    # numpy broadcasting instead of a per-atom python loop
+    replicas = [g.replicas(d=direc) for direc in g.neighbor_directions()]
+    for i in range(len(g.r)):
       r1 = g.r[i] # first position
       nb = 0 # initialize
-      for direc in g.neighbor_directions(): # loop over directions
-        for r2 in g.replicas(d=direc): # loop over replicas
-          dr = r1-r2
-          if d-tol < dr.dot(dr) < d+tol: # if first neighbor
-            nb += 1 # increase counter
+      for r2 in replicas: # loop over directions
+        dr2 = np.sum((r1-r2)**2,axis=1) # squared distances to this direction's replicas
+        nb += np.count_nonzero((d-tol < dr2) & (dr2 < d+tol)) # first neighbors
       if nb<2:
         sb.append(i+0) # add to the list
     gout = remove(g,sb) # remove those atoms

--- a/src/pyqula/sculpt.py
+++ b/src/pyqula/sculpt.py
@@ -411,23 +411,17 @@ def sites_in_unit_cell(r,a1,a2,a3,dim=3):
   """Retain position located in the unit cell defined by a1,a2,a3"""
   R = np.array([a1,a2,a3]).T # transformation matrix
   L = algebra.inv(R) # inverse matrix
-#  d0 = -np.random.random()*0.001 - .5 # accuracy
   d0 = 0.00234231421 - 0.5 # random number
   d1 = 1.0 + d0 # accuracy
-  retain = [] # empty list
-  for ri in r: # loop over positions
-    rn = L@ri  # transform
-    n1,n2,n3 = rn[0],rn[1],rn[2]
-    if dim==3:
-        if d0<n1<d1 and d0<n2<d1 and d0<n3<d1:
-            retain.append(1)
-        else: retain.append(0)
-    if dim==2:
-        if d0<n1<d1 and d0<n2<d1:
-            retain.append(1)
-        else: retain.append(0)
-  retain = np.array(retain)
-  return retain
+  # transform every position at once instead of looping over positions in
+  # python with a per-atom matrix-vector product
+  rn = np.array(r)@L.T # fractional coordinates of every position
+  if dim==3:
+    retain = (d0<rn[:,0])&(rn[:,0]<d1)&(d0<rn[:,1])&(rn[:,1]<d1)&(d0<rn[:,2])&(rn[:,2]<d1)
+  elif dim==2:
+    retain = (d0<rn[:,0])&(rn[:,0]<d1)&(d0<rn[:,1])&(rn[:,1]<d1)
+  else: return np.array([]) # unreached in practice, matches the old behavior
+  return retain.astype(int)
 
 def retain_unit_cell(r,a1,a2,a3,dim=3):
     """Retain position located in the unit cell defined by a1,a2,a3"""

--- a/src/pyqula/supercell.py
+++ b/src/pyqula/supercell.py
@@ -36,44 +36,35 @@ def non_orthogonal_supercell(gin,m,ncheck=2,mode="fill",reducef=lambda x: x):
   # now create replicas until there as c times as many atoms in the
   # unit cell
   if mode=="fill": # look for atoms until everything is filled
-    rs = []
-    k2K = algebra.inv(go.get_k2K()) # matrix transformation
-    R = np.matrix([go.a1,go.a2,go.a3]).T # transformation matrix
+    R = np.array([go.a1,go.a2,go.a3]).T # transformation matrix
     L = algebra.inv(R) # inverse matrix
-    d0 = -np.random.random()*0.1 # accuracy
     d0 = -0.122132112 # some random number
     d1 = 1.0 + d0 # accuracy
     from .geometry import neighbor_cells
 # get as many cells as necessary
     cneigh = reducef(c) # cells to generate given the volume increase c
     cneigh = int(round(cneigh)) # integer
-    inds = neighbor_cells(cneigh,dim=g.dimensionality) 
-    sl = [] # list for the sublattice
-    for (i,j,k) in inds: # loop
-          ii = 0 # start count
-          for ir in range(len(g.r)): # loop over positions
-            ri = g.r[ir] # get the position
-            store = False
-            rj = ri + i*g.a1 + j*g.a2 + k*g.a3 # new position
-            rn = L@np.matrix(rj).T  # transform
-            rn = np.array([rn.T[0,ii] for ii in range(3)]) # convert to array
-            n1,n2,n3 = rn[0],rn[1],rn[2]
-            if g.dimensionality==3 and d0<n1<d1 and d0<n2<d1 and d0<n3<d1:
-                store = True
-            if g.dimensionality==2 and d0<n1<d1 and d0<n2<d1: 
-                store = True
-            if g.dimensionality==1 and d0<n1<d1: 
-                store = True
-            if store:
-                rs.append(rj)
-                if g.has_sublattice: sl.append(g.sublattice[ir])
-#          if len(rs)==len(g.r)*c:
-#            print("All the atoms found")
-#            break
-#    print(rs)
+    inds = np.array(neighbor_cells(cneigh,dim=g.dimensionality))
+    # candidate position of every atom in every candidate cell at once,
+    # vectorized instead of a per-(cell,atom) python loop that built a
+    # np.matrix per atom (this used to dominate the cost of every
+    # twisted-multilayer builder in specialgeometry.py)
+    cell_shifts = inds@np.array([g.a1,g.a2,g.a3]) # shape (ncells,3)
+    rj = g.r[None,:,:] + cell_shifts[:,None,:] # shape (ncells,natoms,3)
+    rn = rj@L.T # fractional coordinates, same shape
+    if g.dimensionality==3:
+      store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)&(d0<rn[...,2])&(rn[...,2]<d1)
+    elif g.dimensionality==2:
+      store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)
+    elif g.dimensionality==1:
+      store = (d0<rn[...,0])&(rn[...,0]<d1)
+    else: store = np.zeros(rn.shape[:-1],dtype=bool)
+    rj = rj.reshape(-1,3) # flatten (cell,atom) -> a single list, cell-major
+    store = store.reshape(-1) # matching flattening
+    rs = rj[store]
     go.r = np.array(rs) # store
-    if go.has_sublattice: go.sublattice = sl # store sublattice
-    if len(rs)!=len(g.r)*c: 
+    if go.has_sublattice: go.sublattice = np.tile(g.sublattice,len(inds))[store] # store sublattice
+    if len(rs)!=len(g.r)*c:
       print("Not all the atoms have been found")
       print("New atoms",len(rs))
       print("Expected atoms",len(g.r)*c)
@@ -144,33 +135,33 @@ def target_angle_volume(g,angle=None,n=5,volume=None,same_length=False):
     a1 = g.a1
     a2 = g.a2
     def getm(): # get the matrix
-      out = [] # empty list
-      vs = [] # volumes
-      for i in range(-n,n+1):
-        for j in range(-n,n+1):
-          for k in range(-n,n+1):
-            for l in range(-n,n+1):
-                store = False
-                a1n = i*a1 + j*a2
-                a2n = k*a1 + l*a2
-                v = lg.norm(np.cross(a1n,a2n)) # new volume
-                v /= lg.norm(np.cross(a1,a2)) # new volume
-                if abs(v)<1e-6: continue # zero volume
-                u1 = a1n/np.sqrt(a1n.dot(a1n)) # normalize
-                u2 = a2n/np.sqrt(a2n.dot(a2n)) # normalize
-                if angle is not None: # check if it has the desired angle
-                    diff = u1.dot(u2)-np.cos(angle*np.pi) # difference
-                    if abs(diff)>1e-6: continue # next try 
-                if same_length: # check if they must have the same length
-                    diff = a1n.dot(a1n) - a2n.dot(a2n)
-                    if abs(diff)>1e-6: continue # next try 
-                if volume is not None: # target such volume
-                    if abs(v-volume)>1e-6: continue
-               #     else: return [[i,j,0],[k,l,0],[0,0,1]]
-                out.append([[i,j,0],[k,l,0],[0,0,1]]) # orthogonal, return
-                vs.append(v) # volume
-      if len(out)==0: return None # nothng found
-      vs = np.array(vs) # as array
+      # evaluate every (i,j,k,l) candidate at once with numpy instead of
+      # calling np.cross/np.linalg.norm once per candidate inside a
+      # python quadruple loop (this used to dominate the cost of every
+      # angle/volume-targeted supercell search)
+      rng = np.arange(-n,n+1)
+      I,J,K,L = np.meshgrid(rng,rng,rng,rng,indexing="ij")
+      I = I.ravel() ; J = J.ravel() ; K = K.ravel() ; L = L.ravel()
+      a1n = I[:,None]*a1[None,:] + J[:,None]*a2[None,:] # shape (ncand,3)
+      a2n = K[:,None]*a1[None,:] + L[:,None]*a2[None,:] # shape (ncand,3)
+      v0 = lg.norm(np.cross(a1,a2))
+      with np.errstate(invalid="ignore",divide="ignore"): # a1n or a2n can be zero
+        v = lg.norm(np.cross(a1n,a2n),axis=1)/v0 # new volume
+        u1 = a1n/np.sqrt(np.sum(a1n*a1n,axis=1))[:,None] # normalize
+        u2 = a2n/np.sqrt(np.sum(a2n*a2n,axis=1))[:,None] # normalize
+      mask = np.abs(v)>=1e-6 # zero volume
+      if angle is not None: # check if it has the desired angle
+        diff = np.sum(u1*u2,axis=1)-np.cos(angle*np.pi) # difference
+        mask &= np.abs(diff)<=1e-6
+      if same_length: # check if they must have the same length
+        diff = np.sum(a1n*a1n,axis=1) - np.sum(a2n*a2n,axis=1)
+        mask &= np.abs(diff)<=1e-6
+      if volume is not None: # target such volume
+        mask &= np.abs(v-volume)<=1e-6
+      idx = np.where(mask)[0]
+      if len(idx)==0: return None # nothng found
+      out = [[[I[i],J[i],0],[K[i],L[i],0],[0,0,1]] for i in idx] # candidates
+      vs = [v[i] for i in idx] # their volumes
       return [o for (v,o) in sorted(zip(vs,out))][0]
     out = getm() # get rotation matrix
     if out is None: raise # no supercell found

--- a/src/pyqula/supercell.py
+++ b/src/pyqula/supercell.py
@@ -45,25 +45,37 @@ def non_orthogonal_supercell(gin,m,ncheck=2,mode="fill",reducef=lambda x: x):
     cneigh = reducef(c) # cells to generate given the volume increase c
     cneigh = int(round(cneigh)) # integer
     inds = np.array(neighbor_cells(cneigh,dim=g.dimensionality))
-    # candidate position of every atom in every candidate cell at once,
-    # vectorized instead of a per-(cell,atom) python loop that built a
-    # np.matrix per atom (this used to dominate the cost of every
-    # twisted-multilayer builder in specialgeometry.py)
-    cell_shifts = inds@np.array([g.a1,g.a2,g.a3]) # shape (ncells,3)
-    rj = g.r[None,:,:] + cell_shifts[:,None,:] # shape (ncells,natoms,3)
-    rn = rj@L.T # fractional coordinates, same shape
-    if g.dimensionality==3:
-      store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)&(d0<rn[...,2])&(rn[...,2]<d1)
-    elif g.dimensionality==2:
-      store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)
-    elif g.dimensionality==1:
-      store = (d0<rn[...,0])&(rn[...,0]<d1)
-    else: store = np.zeros(rn.shape[:-1],dtype=bool)
-    rj = rj.reshape(-1,3) # flatten (cell,atom) -> a single list, cell-major
-    store = store.reshape(-1) # matching flattening
-    rs = rj[store]
-    go.r = np.array(rs) # store
-    if go.has_sublattice: go.sublattice = np.tile(g.sublattice,len(inds))[store] # store sublattice
+    natoms = len(g.r)
+    cell_basis = np.array([g.a1,g.a2,g.a3])
+    # candidate position of every atom in every candidate cell, vectorized
+    # instead of a per-(cell,atom) python loop that built a np.matrix per
+    # atom (this used to dominate the cost of every twisted-multilayer
+    # builder in specialgeometry.py). Candidate cells are processed in
+    # chunks so peak memory stays bounded by chunk size regardless of how
+    # many cells neighbor_cells() produces, instead of materializing every
+    # (cell,atom) candidate position at once.
+    chunk_cells = max(1,200000//max(natoms,1))
+    rs_parts = [] # matched positions, one array per chunk
+    sl_parts = [] # matched sublattice indices, one array per chunk
+    for start in range(0,len(inds),chunk_cells):
+      inds_chunk = inds[start:start+chunk_cells]
+      cell_shifts = inds_chunk@cell_basis # shape (nchunk,3)
+      rj = g.r[None,:,:] + cell_shifts[:,None,:] # shape (nchunk,natoms,3)
+      rn = rj@L.T # fractional coordinates, same shape
+      if g.dimensionality==3:
+        store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)&(d0<rn[...,2])&(rn[...,2]<d1)
+      elif g.dimensionality==2:
+        store = (d0<rn[...,0])&(rn[...,0]<d1)&(d0<rn[...,1])&(rn[...,1]<d1)
+      elif g.dimensionality==1:
+        store = (d0<rn[...,0])&(rn[...,0]<d1)
+      else: store = np.zeros(rn.shape[:-1],dtype=bool)
+      rj = rj.reshape(-1,3) # flatten (cell,atom) -> a single list, cell-major
+      store = store.reshape(-1) # matching flattening
+      rs_parts.append(rj[store])
+      if go.has_sublattice: sl_parts.append(np.tile(g.sublattice,len(inds_chunk))[store])
+    rs = np.concatenate(rs_parts) if rs_parts else np.zeros((0,3))
+    go.r = rs # store
+    if go.has_sublattice: go.sublattice = np.concatenate(sl_parts) if sl_parts else np.array([]) # store sublattice
     if len(rs)!=len(g.r)*c:
       print("Not all the atoms have been found")
       print("New atoms",len(rs))


### PR DESCRIPTION
## Summary

Two rounds of the same fix: a per-atom/per-candidate Python loop that either recomputed something invariant on every iteration or did per-item `np.matrix`/`np.cross` work instead of batching with numpy, plus a follow-up fix for a memory-complexity issue introduced by the vectorization.

**Round 1 — `sculpt.remove_unibonded`** (used by every island-cleaning path: `islands.py`, `mullen.py`, `Geometry.clean()`):
- The pure-Python fallback (used whenever the `clean_geometryf90` Fortran extension isn't compiled) recomputed `g.replicas(d=direc)` from scratch on every iteration of the per-atom loop, even though for 0d geometries (islands) that array never changes. Hoisted it out of the loop and vectorized the inner distance count with numpy.
- Also switched `remove()`'s list membership test to a set, and dropped a dead `from numba import jit` + duplicate `from . import algebra`.

**Round 2 — `specialgeometry.py`'s twisted-bilayer/multilayer builders** (`twisted_bilayer`, `tdbg`, `twisted_multilayer`, `twisted_multimultilayer`, ...): `specialgeometry.py` itself has no bad loops, but every builder in it is bottlenecked by two functions it calls into:
- `supercell.non_orthogonal_supercell`'s `mode="fill"` built a `np.matrix` and did a matrix-vector product per (candidate cell, atom) pair in a nested Python loop, plus computed an unused extra `go.get_k2K()` inversion every call.
- `supercell.target_angle_volume`'s `getm()` brute-forced every `(i,j,k,l)` quadruple with `np.cross`/`np.linalg.norm` calls one at a time.
- `sculpt.sites_in_unit_cell` (used by `specialgeometry.rotate_layer`, once per layer) had the same per-atom-loop-plus-matrix-multiply pattern as round 1's `remove_unibonded`.

All three rewritten to batch the candidate evaluation with numpy instead of a Python loop.

**Round 3 — memory-bounded follow-up** (from an automated code review of rounds 1-2): round 2's `non_orthogonal_supercell` rewrite materialized a dense `(ncells, natoms, 3)` array before filtering, trading the old loop's O(1) extra memory for O(ncells·natoms). `specialgeometry.py`'s twisted-multilayer callers keep this small (`reducef=sqrt` scaling), but the generic public entry point (`Geometry.get_supercell(matrix)` → `non_orthogonal_supercell` with the default `reducef=identity`) has no such scaling, so a large directly-requested supercell matrix could spike memory. Fixed by processing candidate cells in fixed-size chunks, bounding peak memory regardless of the total candidate count. Verified bit-identical output at normal sizes, plus a moderate 30×30 honeycomb supercell (1800 atoms) to confirm correctness without repeating the oversized stress test that caused the original finding.

**Incidental bug fix:** removing the dead `go.get_k2K()` call in `non_orthogonal_supercell` also fixes a pre-existing crash for any 1D geometry (`get_k2K` only supports 2D/3D, so it raised unconditionally before this change).

## Verification
- Round 1: bit-for-bit identical `remove_unibonded` output vs. the original algorithm across several geometries.
- Round 2: cross-checked against the unmodified implementation across several base lattices (honeycomb, square, kagome), multiple `non_orthogonal_supercell`/`target_angle_volume` parameterizations, and full `twisted_bilayer`/`tdbg` builds at several twist indices — via k-d tree nearest-neighbor matching of positions and sublattice labels (exact match, 0.0–1e-14 distance). Plain sorted-array comparison isn't reliable here since rotated honeycomb supercells have many near-tied coordinates that make naive lexsort order unstable between floating-point-equivalent runs.
- Round 3: re-ran the round 2 comparison suite after chunking — output unchanged (chunking is transparent for typical problem sizes, which fit in a single chunk).
- Full test suite: `python -m pytest tests` → 259 passed (all three rounds, run separately).

## Timing

`sculpt.remove_unibonded` (pure-Python path, honeycomb islands):

| atoms | before | after |
|---|---|---|
| 600 | 1.05s | 0.012s |
| 1536 | 7.27s | 0.062s |
| 2904 | 27.57s | 0.167s |
| 4704 | 82.28s | 0.413s |

`specialgeometry.twisted_bilayer(m0)` end-to-end (jit-warm):

| atoms (m0) | before | after |
|---|---|---|
| 364 (m0=5) | 0.66s | 0.13s |
| 1324 (m0=10) | 0.94s | 0.036s |
| 2884 (m0=15) | 1.20s | 0.067s |

`supercell.target_angle_volume(n=5)` alone: ~0.47s → ~0.003s (~150x)

## Test plan
- [x] `python -m pytest tests` passes (259 passed) after each round
- [x] `remove_unibonded`: cross-checked old vs. new output on multiple geometries (identical)
- [x] `non_orthogonal_supercell`/`target_angle_volume`/`sites_in_unit_cell`: cross-checked old vs. new via k-d tree position/sublattice matching across honeycomb/square/kagome base lattices and multiple twisted-bilayer twist indices
- [x] Confirmed the 1D-geometry crash fix (`non_orthogonal_supercell` on a chain now works instead of raising)
- [x] Confirmed the chunked `non_orthogonal_supercell` still matches unchunked output exactly, and runs correctly on a moderate 30×30 supercell

🤖 Generated with [Claude Code](https://claude.com/claude-code)