### PR TITLE
geometry: vectorize remove_duplicated_positions's O(N^2) python loop

### DIFF
--- a/src/pyqula/geometry.py
+++ b/src/pyqula/geometry.py
@@ -927,16 +927,21 @@ def remove_duplicated(g):
 
 
 def remove_duplicated_positions(r):
-  rs = []
+  r = np.array(r) # as array
+  if len(r)==0: return np.zeros((0,3))
+  rs = np.empty(r.shape) # upper bound on the number of kept atoms
+  nkept = 0 # number of atoms kept so far
   for ir in r: # loop over atoms
-     store = True # store this atom
-     for jr in rs: # loop over stored
-       dr = ir-jr
-       dr = dr.dot(dr) # distance
-       if dr<0.01: store = False
+     if nkept==0: store = True # nothing stored yet
+     else: # compare against every already-kept atom at once instead of
+       # a per-pair python loop (this used to be O(natoms^2) with a
+       # python-level distance computation on every pair)
+       dr = rs[:nkept]-ir
+       store = not np.any(np.sum(dr*dr,axis=1)<0.01)
      if store: # store this atom
-       rs.append(ir.copy())
-  return np.array(rs) # return unrepeated atoms
+       rs[nkept] = ir
+       nkept += 1
+  return rs[:nkept].copy() # return unrepeated atoms
 
 
 


### PR DESCRIPTION
## Summary

`remove_duplicated_positions` (`geometry.py`) had a per-pair pure-Python distance check (`for ir in r: for jr in rs: ...`) — the same pattern already fixed this session in `sculpt.remove_unibonded` and `supercell.non_orthogonal_supercell`/`target_angle_volume`/`sites_in_unit_cell` (see #39).

The maintainer had already independently run into this: `kekule.py` imports the function (`remove_duplicated = geometry.remove_duplicated_positions`) but never actually calls that alias — it defines its own `_fast_remove_duplicated` instead, specifically because (per its own docstring) the generic version is "O(N^2)... for the (often large...) hexagon-center lists." So this was diagnosed once already and patched around locally rather than fixed at the source. This PR fixes the source.

Rewritten to keep the *exact same* greedy sequential semantics — each candidate is compared only against already-kept points, so it's still technically O(N²) in the worst case and order-dependent for chains of near-duplicates — but replaces the per-pair Python loop with a numpy batch comparison against the current kept set (same technique as the `remove_unibonded` fix).

**Current impact:** `geometry.remove_duplicated`/`remove_duplicated_positions` has zero live internal callers today (only a dead alias in `kekule.py`, and one commented-out usage in `geometrytk/write.py`), so nothing in the current examples/tests exercises this path. It's public API though, so any external caller building a geometry with a few thousand candidate positions and calling this directly would hit the slowdown silently.

## Verification
- 20 random trials (various N, dense enough to force lots of near-duplicates) — identical output to the original implementation.
- An order-dependent edge case: points spaced just under the distance threshold apart in a chain, specifically to exercise the "only compare against already-kept points" greedy behavior — identical output.
- Single-point case — identical.
- Empty-array case differs: old code returned shape `(0,)` (from `np.array([])`), which would already crash downstream in `remove_duplicated`'s `r2xyz()` (indexes `r[0]` on a 0-length axis). New code returns a proper `(0,3)` array — a latent-bug fix, not a regression, since old empty-input behavior was already non-functional downstream.
- Full test suite: `python -m pytest tests` → 259 passed.

## Timing

| n | before | after |
|---|---|---|
| 500 | 0.068s | 0.005s |
| 1000 | 0.271s | 0.013s |
| 2000 | 1.140s | 0.055s |
| 4000 | ~4.5s (extrapolated) | 0.161s |

## Test plan
- [x] `python -m pytest tests` passes (259 passed)
- [x] Cross-checked old vs. new output: 20 random trials, chain-of-near-duplicates order-dependent case, single-point case (all identical)
- [x] Confirmed the empty-array shape difference is a pre-existing downstream-crash bug fix, not a behavior regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)