### PR TITLE
Performance: O(N log N) rashba/kanemele/haldane, plus code-review fixes

### DIFF
--- a/src/pyqula/kanemele.py
+++ b/src/pyqula/kanemele.py
@@ -117,7 +117,10 @@ def haldane(r1,r2,rm,fun=0.0,sublattice=None):
     rm = np.array(rm)
     from . import neighbor
     neighs = neighbor.connections(r1,rm) # list with neighbors of each site
-    indsj_all = neighbor.find_close_neighbors_batch(r1,r2,d=1.9) # candidate final sites, per i
+    # radius must be >= sqrt(4.1) to match the dr.dot(dr)<4.1 acceptance
+    # test below -- this pre-filter used to be a tighter d=1.9, which
+    # silently dropped genuine bonds with distance in (1.9, sqrt(4.1))
+    indsj_all = neighbor.find_close_neighbors_batch(r1,r2,d=np.sqrt(4.1)) # candidate final sites, per i
     rows,cols,data = [],[],[]
     for i in range(nsites): # loop over initial site
       rijs_idx = neighs[i] # first neighbors of site i

--- a/src/pyqula/kanemele.py
+++ b/src/pyqula/kanemele.py
@@ -1,42 +1,74 @@
 from __future__ import print_function
-from scipy.sparse import csc_matrix,bmat
+from scipy.sparse import coo_matrix
 from .rotate_spin import sx,sy,sz
 import numpy as np
 from numba import jit
 from . import parallel
 
-from .algebra import isnumber 
+from .algebra import isnumber
+
+# dense 2x2 Pauli matrices, converted once at import time: building each
+# bond's 2x2 spin block via scipy-sparse sx/sy/sz arithmetic (as this used
+# to be written) pays scipy's per-call sparse bookkeeping (format checks,
+# index-dtype inference, prune...) on every single bond -- see rashba.py
+# for the same fix and the profiling that motivated it.
+_sx = np.asarray(sx.todense())
+_sy = np.asarray(sy.todense())
+_sz = np.asarray(sz.todense())
+
 
 def generalized_kane_mele(r1,r2,rm,fun=0.0,tol=1e-5):
-    """Return the Kane-Mele generalized Hamiltonian"""
+    """Return the Kane-Mele generalized Hamiltonian.
+
+    Only second-neighbor bonds mediated by a real first-neighbor path
+    contribute, so this builds the (2*nsites,2*nsites) sparse matrix
+    directly from that (typically O(nsites)) bond list, found via a
+    KD-tree batch query (find_close_neighbors_batch, O(N log N) total)
+    instead of one O(len(rm))/O(len(r2)) scan per site (O(N^2) total) --
+    and never allocates an nsites x nsites Python list of blocks for
+    scipy.sparse.bmat regardless of sparsity, which used to be infeasible
+    in time and memory for nsites beyond a few thousand.
+    """
     if fun==0.0: return 0
     if isnumber(fun): kmfun = lambda r: fun # function that always returns fun
     elif callable(fun): kmfun = fun # callable function
     else: raise # no idea
     nsites = len(r1) # number of sites
-    mout = [[None for i in range(nsites)] for j in range(nsites)]
-    for i in range(nsites):
-        mout[i][i] = csc_matrix(np.zeros((2,2))) 
-    from .neighbor import find_first_neighbor,find_close_neighbors
     rm = np.array(rm)
     r1 = np.array(r1)
     r2 = np.array(r2)
+    from .neighbor import find_close_neighbors_batch
+    indsim_all = find_close_neighbors_batch(r1,rm,d=1.1) # candidate intermediate sites, per i
+    indsj_all = find_close_neighbors_batch(r1,r2,d=4.1) # candidate final sites, per i
+    ii,jj,urx,ury,urz,cvals = [],[],[],[],[],[]
     for i in range(nsites): # loop over initial site
-        indsim = find_close_neighbors(r1[i],rm,d=1.1) # get close enough
-        rmi = [rm[im] for im in indsim] # retain only those sites for the loop
-        indsj = find_close_neighbors(r1[i],r2,d=4.1) # get close enough
-        # this can (and should) be done more efficiently
-        for j in indsj: # loop over final site
+        indsim = indsim_all[i]
+        if len(indsim)==0: continue
+        rmi = rm[indsim] # retain only those sites for the loop
+        for j in indsj_all[i]: # loop over final site
             dr = r1[i]-r2[j] # difference
-            if dr.dot(dr)<4.1: # if close enough
-                ur = km_vector(r1[i],r2[j],rmi,tol=tol) # kane mele vector
-                r3 = (r1[i] + r2[j])/2.0
-                sm = (sx*ur[0] + sy*ur[1] + sz*ur[2])*kmfun(r3) # contribution
-                if mout[i][j] is None: 
-                    mout[i][j] = csc_matrix(1j*sm) # add contribution
-                else: 
-                    mout[i][j] += csc_matrix(1j*sm) # add contribution
-    return bmat(mout) # return matrix
+            if dr.dot(dr)>=4.1: continue # not close enough
+            ur = km_vector(r1[i],r2[j],rmi,tol=tol) # kane mele vector
+            if ur[0]==0.0 and ur[1]==0.0 and ur[2]==0.0: continue # no bond path found
+            r3 = (r1[i] + r2[j])/2.0
+            ii.append(i); jj.append(j)
+            urx.append(ur[0]); ury.append(ur[1]); urz.append(ur[2])
+            cvals.append(kmfun(r3))
+    if len(ii)==0: return coo_matrix((2*nsites,2*nsites),dtype=np.complex128)
+    ii = np.array(ii); jj = np.array(jj)
+    urx = np.array(urx); ury = np.array(ury); urz = np.array(urz)
+    cvals = np.array(cvals,dtype=np.complex128)
+    # cross-product-with-sigma * coupling strength, for every bond at once
+    sm = 1j*(urx[:,None,None]*_sx + ury[:,None,None]*_sy
+            + urz[:,None,None]*_sz)*cvals[:,None,None] # (nbonds,2,2)
+    a_idx = np.array([0,0,1,1])
+    b_idx = np.array([0,1,0,1])
+    rows = (2*ii[:,None] + a_idx[None,:]).reshape(-1)
+    cols = (2*jj[:,None] + b_idx[None,:]).reshape(-1)
+    data = sm[:,a_idx,b_idx].reshape(-1)
+    keep = data!=0.0
+    return coo_matrix((data[keep],(rows[keep],cols[keep])),
+            shape=(2*nsites,2*nsites),dtype=np.complex128)
 
 
 def km_vector(ri,rj,rm,tol=1e-5):
@@ -63,9 +95,17 @@ def km_vector_jit(ri,rj,v,rm,tol=1e-5):
 
 
 def haldane(r1,r2,rm,fun=0.0,sublattice=None):
-    """Return the Haldane coupling"""
+    """Return the Haldane coupling.
+
+    Builds the (nsites,nsites) sparse matrix from the (typically
+    O(nsites)) bond list directly, instead of allocating a fully dense
+    nsites x nsites complex array (160GB+ for nsites~1e5) -- and finds
+    the candidate final sites for every site with one shared KD-tree
+    query (find_close_neighbors_batch) instead of one O(len(r2)) scan per
+    site."""
+    r1 = np.array(r1)
     if sublattice is None: sublattice = np.zeros(len(r1)) + 1.0
-    if isnumber(fun): 
+    if isnumber(fun):
         if fun==0.0: return 0 # skip
         kmfun = lambda r: fun # function that always returns fun
     elif callable(fun): kmfun = fun # callable function
@@ -73,21 +113,27 @@ def haldane(r1,r2,rm,fun=0.0,sublattice=None):
         from .potentials import array2potential
         kmfun = array2potential(r1[:,0],r1[:,1],fun)
     nsites = len(r1) # number of sites
-    mout = np.zeros((nsites,nsites),dtype=np.complex128) # initialize
+    r2 = np.array(r2)
+    rm = np.array(rm)
     from . import neighbor
     neighs = neighbor.connections(r1,rm) # list with neighbors of each site
+    indsj_all = neighbor.find_close_neighbors_batch(r1,r2,d=1.9) # candidate final sites, per i
+    rows,cols,data = [],[],[]
     for i in range(nsites): # loop over initial site
-      rijs = [rm[kk] for kk in neighs[i]] # loop over first neighbors
-      if len(rijs)==0: continue
-      indsj = neighbor.find_close_neighbors(r1[i],r2,d=1.9) # get close enough
-      for j in indsj: # loop over final site
+      rijs_idx = neighs[i] # first neighbors of site i
+      if len(rijs_idx)==0: continue
+      rijs = rm[rijs_idx]
+      for j in indsj_all[i]: # loop over final site
         dr = r1[i]-r2[j] # difference
-        if dr.dot(dr)<4.1:
-            ur = km_vector(r1[i],r2[j],rijs) # kane mele vector
-            r3 = (r1[i] + r2[j])/2.0
-            sm = ur[2]*kmfun(r3) # clockwise or anticlockwise
-            mout[i,j] = 1j*sm*(sublattice[i]+sublattice[j])/2. # store
-    return csc_matrix(mout) # return matrix
+        if dr.dot(dr)>=4.1: continue
+        ur = km_vector(r1[i],r2[j],rijs) # kane mele vector
+        if ur[2]==0.0: continue
+        r3 = (r1[i] + r2[j])/2.0
+        v = 1j*ur[2]*kmfun(r3)*(sublattice[i]+sublattice[j])/2. # clockwise or anticlockwise
+        if v!=0.0:
+            rows.append(i); cols.append(j); data.append(v)
+    return coo_matrix((data,(rows,cols)),shape=(nsites,nsites),
+            dtype=np.complex128) # return matrix
 
 
 

--- a/src/pyqula/multicell.py
+++ b/src/pyqula/multicell.py
@@ -428,10 +428,29 @@ def pairs2hopping(ps):
 
 
 
-@jit(nopython=True)
 def close_enough(rs1,rs2,rcut=2.0):
-    """Check if two sets of positions are at a distance
-    at least rcut"""
+    """Check if any pair of points from rs1 and rs2 are within rcut of
+    each other.
+
+    Uses a KD-tree instead of the all-pairs O(len(rs1)*len(rs2)) scan in
+    close_enough_bruteforce below: that scan has an early exit for the
+    common "yes, they're close" case, but confirming "no, nothing is
+    close" -- which happens routinely here, e.g. for a candidate
+    lattice-cell shift too far to matter -- still needs the full scan,
+    measured at ~10s for two ~1e4-site position sets."""
+    from scipy.spatial import cKDTree
+    rs1 = np.asarray(rs1,dtype=np.float64)
+    rs2 = np.asarray(rs2,dtype=np.float64)
+    if len(rs1)==0 or len(rs2)==0: return False
+    dists,_ = cKDTree(rs1).query(rs2,k=1)
+    return bool(np.any(dists<rcut))
+
+
+@jit(nopython=True)
+def close_enough_bruteforce(rs1,rs2,rcut=2.0):
+    """O(len(rs1)*len(rs2)) reference implementation of close_enough,
+    kept for testing against (see tests/geometry/test_neighbor_kdtree.py
+    -- or wherever the corresponding regression test lives)."""
     rcut2 = rcut*rcut # square of the distance
     for ri in rs1:
       for rj in rs2:

--- a/src/pyqula/neighbor.py
+++ b/src/pyqula/neighbor.py
@@ -47,13 +47,34 @@ def find_close_neighbors_jit(r0,rs,d=2.0):
 
 
 def find_first_neighbor(r1,r2):
-     """Calls the fortran routine"""
-     r1 = np.array(r1)
-     r2 = np.array(r2)
-     nn = number_neighbors_jit(r1.real,r2.real) # number of first neighbors
-     out = np.zeros((nn,2),dtype=np.int_) # generate indexes
-     out = find_first_neighbor_jit(r1.real,r2.real,out) # generate all the pairs
-     return out
+     """Return the (i,j) index pairs of first neighbors between the point
+     sets r1 and r2, i.e. 0.99<|r1[i]-r2[j]|^2<1.01.
+
+     Uses a KD-tree to only compare points that are actually close to each
+     other, instead of number_neighbors_jit/find_first_neighbor_jit's
+     all-pairs O(N^2) scan below (kept for testing): for N~1e5 sites the
+     O(N^2) scan is 1e10 distance checks, infeasible in time even jitted,
+     while the KD-tree query is O(N log N)."""
+     from scipy.spatial import cKDTree
+     r1 = np.array(r1,dtype=np.float64).real
+     r2 = np.array(r2,dtype=np.float64).real
+     if len(r1)==0 or len(r2)==0: return np.zeros((0,2),dtype=np.int_)
+     tree = cKDTree(r2)
+     # candidates within a slightly generous radius; the exact
+     # 0.99<dr^2<1.01 criterion is applied below since query_ball_point's
+     # own radius test (dr^2<=r^2) is a different (inclusive) boundary
+     candidates = tree.query_ball_point(r1,r=np.sqrt(1.01),workers=-1)
+     rows,cols = [],[]
+     for i,js in enumerate(candidates):
+         if len(js)==0: continue
+         js = np.array(sorted(js),dtype=np.int_)
+         dr = r2[js]-r1[i]
+         dr2 = np.sum(dr*dr,axis=1)
+         sel = js[(dr2>0.99) & (dr2<1.01)]
+         rows.extend([i]*len(sel))
+         cols.extend(sel.tolist())
+     if len(rows)==0: return np.zeros((0,2),dtype=np.int_)
+     return np.array([rows,cols],dtype=np.int_).T
 
 @jit(nopython=True)
 def number_neighbors_jit(r1,r2):
@@ -83,6 +104,17 @@ def find_first_neighbor_jit(r1,r2,pairs):
              pairs[out,1] = j
              out += 1 # increase
     return pairs # indexes of the neighbors
+
+
+def find_first_neighbor_bruteforce(r1,r2):
+    """O(N^2) reference implementation of find_first_neighbor, kept for
+    testing the KD-tree version above against (see
+    tests/geometry/test_neighbor_kdtree.py)."""
+    r1 = np.array(r1,dtype=np.float64).real
+    r2 = np.array(r2,dtype=np.float64).real
+    nn = number_neighbors_jit(r1,r2)
+    out = np.zeros((nn,2),dtype=np.int_)
+    return find_first_neighbor_jit(r1,r2,out)
 
 
 

--- a/src/pyqula/neighbor.py
+++ b/src/pyqula/neighbor.py
@@ -30,6 +30,24 @@ def find_close_neighbors(r0,rs,d=2.0):
     return find_close_neighbors_jit(np.array(r0),np.array(rs),d=d)
 
 
+def find_close_neighbors_batch(r1,rs,d=2.0):
+    """Return, for every point in r1, the indexes of the points in rs
+    closer than distance d -- i.e. the same criterion as
+    find_close_neighbors, but for many query points at once against one
+    shared KD-tree over rs (built once), instead of one O(len(rs)) scan
+    per query point (kanemele.py calls find_close_neighbors once per site
+    in a Python loop, which is O(N^2) total for N sites; this is
+    O(N log N))."""
+    from scipy.spatial import cKDTree
+    r1 = np.array(r1,dtype=np.float64).real
+    rs = np.array(rs,dtype=np.float64).real
+    if len(rs)==0 or len(r1)==0:
+        return [np.zeros(0,dtype=np.int_) for _ in range(len(r1))]
+    tree = cKDTree(rs)
+    neighbors = tree.query_ball_point(r1,r=d)
+    return [np.array(js,dtype=np.int_) for js in neighbors]
+
+
 @jit(nopython=True)
 def find_close_neighbors_jit(r0,rs,d=2.0):
     """Return the indexes of the neighbors that are closer than a

--- a/src/pyqula/neighbor.py
+++ b/src/pyqula/neighbor.py
@@ -62,8 +62,11 @@ def find_first_neighbor(r1,r2):
      tree = cKDTree(r2)
      # candidates within a slightly generous radius; the exact
      # 0.99<dr^2<1.01 criterion is applied below since query_ball_point's
-     # own radius test (dr^2<=r^2) is a different (inclusive) boundary
-     candidates = tree.query_ball_point(r1,r=np.sqrt(1.01),workers=-1)
+     # own radius test (dr^2<=r^2) is a different (inclusive) boundary.
+     # No workers= kwarg here: pyproject.toml doesn't pin a scipy floor,
+     # and workers= only exists from scipy>=1.6 -- single-threaded is a
+     # small fraction of a second even at 1e5 sites, not worth requiring it
+     candidates = tree.query_ball_point(r1,r=np.sqrt(1.01))
      rows,cols = [],[]
      for i,js in enumerate(candidates):
          if len(js)==0: continue

--- a/src/pyqula/rashba.py
+++ b/src/pyqula/rashba.py
@@ -1,7 +1,19 @@
 import numpy as np
-from scipy.sparse import coo_matrix,bmat
+from scipy.sparse import coo_matrix
 from .rotate_spin import sx,sy,sz
 from . import neighbor
+
+# dense 2x2 Pauli matrices, converted once at import time: rashba_matrix
+# below needs one 2x2 spin block per bond (potentially hundreds of
+# thousands of them for a large flake), and building each one out of
+# scipy-sparse sx/sy/sz arithmetic pays scipy's per-call sparse-matrix
+# bookkeeping (format checks, index-dtype inference, prune...) every
+# single bond; a plain numpy array has none of that overhead and lets all
+# bonds be combined into a handful of vectorized array operations instead
+# of a Python loop of scipy calls.
+_sx = np.asarray(sx.todense())
+_sy = np.asarray(sy.todense())
+_sz = np.asarray(sz.todense())
 
 def add_rashba(self,c):
     """
@@ -50,28 +62,49 @@ def rashba_matrix(r1,r2=None,c=0.,d=[0.,0.,1.],is_sparse=False):
   """
   Add Rashba coupling, returns a spin polarized matrix
   This will assume only Rashba between first neighbors
+
+  Only first-neighbor bonds ever contribute (Rashba is a nearest-neighbor
+  term), so this builds the (2*nat1,2*nat2) sparse matrix directly from
+  that (typically O(nat)) list of bonds, instead of allocating an
+  nat1 x nat2 Python list of 2x2 blocks and handing it to scipy.sparse.bmat
+  regardless of how few of those blocks are actually nonzero -- the old
+  approach needed nat1*nat2 Python object slots up front (~1e10 for
+  nat~1e5), infeasible in both time and memory well before bmat even ran.
   """
-  zero = coo_matrix([[0.,0.],[0.,0.]])
   if r2 is None:
     r2 = r1
-  nat = len(r1) # number of atoms
-  m = [[None for i in range(nat)] for j in range(nat)] # create matrix
-  for i in range(nat): m[i][i] = zero.copy() # initilize
-  neighs = neighbor.connections(r1,r2) # neighbor connections
-  for i in range(nat): # loop over first atoms
-#    for j in range(nat):  # loop over second atoms
-    for j in neighs[i]:  # loop over second atoms
-      rij = r2[j] - r1[i]   # x component
-      dx,dy,dz = rij[0],rij[1],rij[2]  # different components
-      rxs = [dy*sz-dz*sy,dz*sx-dx*sz,dx*sy-dy*sx]  # cross product
-      ms = 1j*(d[0]*rxs[0] + d[1]*rxs[1] + d[2]*rxs[2]) # E dot r times s
-      s = 0.0*ms
-      if 0.9<(rij.dot(rij))<1.1: # if nearest neighbor
-        if callable(c): s = ms*c((r1[i]+r2[j])/2.) # function
-        else: s = ms*c # multiply
-      m[i][j] = s # rashba term
-  if not is_sparse: m = bmat(m).todense()  # to normal matrix
-  else: m = bmat(m) # sparse matrix
+  r1 = np.array(r1)
+  r2 = np.array(r2)
+  nat1 = len(r1)
+  nat2 = len(r2)
+  pairs = neighbor.find_first_neighbor(r1,r2) # (i,j) first-neighbor bonds
+  if len(pairs)==0:
+    m = coo_matrix(([],([],[])),shape=(2*nat1,2*nat2),dtype=np.complex128)
+    if not is_sparse: m = m.todense()
+    return m
+  ii,jj = pairs[:,0],pairs[:,1]
+  rij = r2[jj] - r1[ii] # (nbonds,3), one bond vector per row
+  dx,dy,dz = rij[:,0],rij[:,1],rij[:,2] # (nbonds,)
+  # cross product with the Pauli vector, for every bond at once:
+  # (nbonds,2,2)
+  rxs0 = dy[:,None,None]*_sz - dz[:,None,None]*_sy
+  rxs1 = dz[:,None,None]*_sx - dx[:,None,None]*_sz
+  rxs2 = dx[:,None,None]*_sy - dy[:,None,None]*_sx
+  ms = 1j*(d[0]*rxs0 + d[1]*rxs1 + d[2]*rxs2) # (nbonds,2,2)
+  if callable(c): # position-dependent strength: one python call per bond
+    mid = (r1[ii]+r2[jj])/2.
+    cvals = np.array([c(p) for p in mid],dtype=np.complex128)
+    s = ms*cvals[:,None,None]
+  else: s = ms*c # constant strength: one vectorized multiply
+  a_idx = np.array([0,0,1,1])
+  b_idx = np.array([0,1,0,1])
+  rows = (2*ii[:,None] + a_idx[None,:]).reshape(-1)
+  cols = (2*jj[:,None] + b_idx[None,:]).reshape(-1)
+  data = s[:,a_idx,b_idx].reshape(-1)
+  keep = data!=0.0
+  m = coo_matrix((data[keep],(rows[keep],cols[keep])),
+          shape=(2*nat1,2*nat2),dtype=np.complex128)
+  if not is_sparse: m = m.todense() # to normal matrix
   return m
 
 

--- a/src/pyqula/transporttk/kappa.py
+++ b/src/pyqula/transporttk/kappa.py
@@ -171,8 +171,14 @@ def get_kappa_finite_temperature_energies(HT,energies=[0.0],temp=1e-2,**kwargs):
         # at all, which is what the non-superconducting branch (and a
         # superconducting branch whose build didn't converge) should get.
         extra = {"selfenergy_qtci": shared} if shared is not None else {}
+        # dict.update, not **extra,**kwargs: if the caller already passed
+        # their own selfenergy_qtci in kwargs, unpacking both would raise
+        # "got multiple values for keyword argument" instead of letting
+        # the freshly-built, branch-specific shared interpolant win
+        call_kwargs = dict(kwargs)
+        call_kwargs.update(extra)
         ts,Gs = get_conductances_finite_temp(
-            HT=ht,energies=energies,temp=temp,**extra,**kwargs)
+            HT=ht,energies=energies,temp=temp,**call_kwargs)
         return np.array([get_power(ts,g) for g in Gs.T])
     ks1 = branch_kappas(True)
     ks2 = branch_kappas(False)

--- a/src/pyqula/transporttk/localprobe.py
+++ b/src/pyqula/transporttk/localprobe.py
@@ -13,7 +13,7 @@ gfmode = "adaptive"
 
 
 class LocalProbe():
-    def __init__(self,h,lead=None,delta=1e-5,i=0,T=1.0,**kwargs):
+    def __init__(self,h,lead=None,delta=1e-6,i=0,T=1.0,**kwargs):
         h = h.get_dense() # dense Hamiltonian
         self.H = h.copy() # store Hamiltonian
         # Precompute the non-multicell form once, when valid (nearest-
@@ -67,9 +67,19 @@ class LocalProbe():
         method-selecting didv() directly, so that a `temp` kwarg here
         actually reaches transporttk.thermaldidv.finite_T_didv instead of
         being silently forwarded into a method (smatrix/keldysh) that
-        never looks at it -- at temp=0 (the default) this reduces to
-        exactly the previous zero_T_didv_1D(self,...)->didv(self,...) call
-        chain, so existing zero-temperature behavior is unchanged."""
+        never looks at it.
+
+        At temp=0 (the default) this now goes through zero_T_didv, which
+        defaults an unspecified delta to self.delta -- matching
+        Heterostructure.didv's own convention -- rather than the bare
+        didv()'s hardcoded delta=1e-6 that LocalProbe.didv used to fall
+        through to before this routing existed. __init__'s own delta
+        default is 1e-6 precisely so a caller who never touches delta
+        anywhere still gets that same number; only a caller who
+        constructs LocalProbe with an explicit delta=... now sees it
+        consistently applied to didv() as well, rather than silently
+        ignored in favor of 1e-6. Pass delta=... to didv() itself to
+        override either default directly."""
         from .didv import generic_didv
         return generic_didv(self,**kwargs)
     def get_dc_current(self,voltage,**kwargs):

--- a/tests/geometry/test_close_enough_kdtree.py
+++ b/tests/geometry/test_close_enough_kdtree.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.multicell import close_enough, close_enough_bruteforce
+
+
+def test_close_enough_kdtree_matches_bruteforce():
+    """close_enough's KD-tree implementation must agree with the O(N^2)
+    brute-force reference for both nearby and far-apart shifted-cell
+    position sets (the case that used to force the reference's full,
+    non-early-exiting scan), and for the empty-input edge case."""
+    g = geometry.honeycomb_lattice().get_supercell(6)
+    r1 = g.r
+    for i in range(-2, 3):
+        for j in range(-2, 3):
+            rtmp = np.array([ir + i * g.a1 + j * g.a2 for ir in g.r])
+            a = close_enough(r1, rtmp, rcut=2.1)
+            b = close_enough_bruteforce(r1, rtmp, rcut=2.1)
+            assert a == b, (i, j)
+
+    empty = np.zeros((0, 3))
+    assert close_enough(empty, r1, rcut=2.1) == False
+    assert close_enough(r1, empty, rcut=2.1) == False

--- a/tests/geometry/test_neighbor_kdtree.py
+++ b/tests/geometry/test_neighbor_kdtree.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.neighbor import find_first_neighbor, find_first_neighbor_bruteforce
+
+
+def _as_set(pairs):
+    return set((int(i), int(j)) for i, j in pairs)
+
+
+def test_kdtree_neighbor_search_matches_bruteforce():
+    """find_first_neighbor's KD-tree search must find exactly the same
+    (i,j) first-neighbor pairs as the O(N^2) brute-force reference, for
+    both r1==r2 and r1!=r2 (as used for the tx/ty/inter shifted-cell
+    hoppings), across several lattices."""
+    cases = []
+    g = geometry.honeycomb_lattice().get_supercell(6)
+    cases.append(("honeycomb_super", g.r, g.r))
+    g = geometry.kagome_lattice().get_supercell(4)
+    cases.append(("kagome_super", g.r, g.r))
+    g = geometry.triangular_lattice().get_supercell(5)
+    cases.append(("triangular_super", g.r, g.r))
+    g = geometry.honeycomb_lattice().get_supercell(5)
+    r2 = [ir + g.a1 for ir in g.r]
+    cases.append(("honeycomb_shifted", g.r, r2))
+    g = geometry.chain()
+    cases.append(("single_atom_no_neighbors", g.r, g.r))
+
+    for name, r1, r2 in cases:
+        a = find_first_neighbor(r1, r2)
+        b = find_first_neighbor_bruteforce(r1, r2)
+        assert _as_set(a) == _as_set(b), name

--- a/tests/hopping/test_add_rashba_sparse.py
+++ b/tests/hopping/test_add_rashba_sparse.py
@@ -67,6 +67,20 @@ def test_rashba_matrix_matches_dense_reference():
         assert np.max(np.abs(got - ref)) < 1e-10, (name, "custom_d")
 
 
+def test_rashba_matrix_edge_localized_profile_matches_dense_reference():
+    """A common physical use case: Rashba coupling confined to an edge or
+    interface, i.e. c(r) is exactly zero over most of the flake. This
+    specifically exercises the `data!=0.0` zero-filtering in the
+    vectorized bond construction, not just a smooth nonzero profile."""
+    g = geometry.honeycomb_lattice().get_supercell(6)
+    r1 = g.r
+    profile = lambda p: 0.4 if p[0] > 3.0 else 0.0
+    got = _dense(rashba_matrix(r1, r2=r1, c=profile, is_sparse=True))
+    ref = _dense_reference_rashba(r1, r1, profile)
+    assert np.max(np.abs(got - ref)) < 1e-10
+    assert 0 < np.count_nonzero(got) < got.size  # neither all-zero nor all-nonzero
+
+
 def test_add_rashba_produces_finite_sparse_hamiltonian():
     """End-to-end add_rashba, including on top of SOC and exchange terms,
     must stay finite and sparse."""

--- a/tests/hopping/test_add_rashba_sparse.py
+++ b/tests/hopping/test_add_rashba_sparse.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.rashba import rashba_matrix
+
+_sx = np.array([[0., 1.], [1., 0.]])
+_sy = np.array([[0., -1j], [1j, 0.]])
+_sz = np.array([[1., 0.], [0., -1.]])
+
+
+def _dense_reference_rashba(r1, r2, c, d=(0., 0., 1.)):
+    """Independent O(N^2) dense reference for the Rashba matrix, built
+    directly from the Pauli matrices without going through neighbor.py or
+    any of the vectorized bond machinery in rashba.rashba_matrix."""
+    r1 = np.array(r1); r2 = np.array(r2)
+    n1, n2 = len(r1), len(r2)
+    m = np.zeros((2 * n1, 2 * n2), dtype=complex)
+    for i in range(n1):
+        for j in range(n2):
+            rij = r2[j] - r1[i]
+            if not (0.99 < rij.dot(rij) < 1.01):
+                continue
+            dx, dy, dz = rij
+            rxs = [dy * _sz - dz * _sy, dz * _sx - dx * _sz, dx * _sy - dy * _sx]
+            ms = 1j * (d[0] * rxs[0] + d[1] * rxs[1] + d[2] * rxs[2])
+            cv = c((r1[i] + r2[j]) / 2.) if callable(c) else c
+            m[2 * i:2 * i + 2, 2 * j:2 * j + 2] = ms * cv
+    return m
+
+
+def _dense(m):
+    return np.asarray(m.todense()) if hasattr(m, "todense") else np.asarray(m)
+
+
+def _geometries():
+    cases = {}
+    g = geometry.honeycomb_lattice().get_supercell(4)
+    cases["honeycomb"] = (g.r, g.r)
+    g = geometry.kagome_lattice().get_supercell(3)
+    cases["kagome"] = (g.r, g.r)
+    g = geometry.triangular_lattice().get_supercell(4)
+    cases["triangular"] = (g.r, g.r)
+    g = geometry.honeycomb_lattice().get_supercell(4)
+    cases["honeycomb_shifted"] = (g.r, [ir + g.a1 for ir in g.r])
+    return cases
+
+
+def test_rashba_matrix_matches_dense_reference():
+    """rashba_matrix (KD-tree neighbor search + vectorized 2x2 spin-block
+    construction) must match a fully independent, dense O(N^2) reference,
+    for constant and position-dependent Rashba strength, and for a
+    non-z spin quantization axis."""
+    for name, (r1, r2) in _geometries().items():
+        for is_sparse in [False, True]:
+            got = _dense(rashba_matrix(r1, r2=r2, c=0.3, is_sparse=is_sparse))
+            ref = _dense_reference_rashba(r1, r2, 0.3)
+            assert np.max(np.abs(got - ref)) < 1e-10, (name, is_sparse)
+
+        got = _dense(rashba_matrix(r1, r2=r2, c=lambda p: 0.2 + 0.1 * p[0],
+                is_sparse=True))
+        ref = _dense_reference_rashba(r1, r2, lambda p: 0.2 + 0.1 * p[0])
+        assert np.max(np.abs(got - ref)) < 1e-10, (name, "callable_c")
+
+        d = [0.3, 0.5, 0.8]
+        got = _dense(rashba_matrix(r1, r2=r2, c=0.3, d=d, is_sparse=True))
+        ref = _dense_reference_rashba(r1, r2, 0.3, d=d)
+        assert np.max(np.abs(got - ref)) < 1e-10, (name, "custom_d")
+
+
+def test_add_rashba_produces_finite_sparse_hamiltonian():
+    """End-to-end add_rashba, including on top of SOC and exchange terms,
+    must stay finite and sparse."""
+    g = geometry.honeycomb_lattice().get_supercell(4)
+    g.dimensionality = 0
+    for setup in ["plain", "soc", "exchange", "soc_exchange"]:
+        h = g.get_hamiltonian(is_sparse=True)
+        if setup in ("soc", "soc_exchange"): h.add_soc(0.1)
+        if setup in ("exchange", "soc_exchange"): h.add_exchange([0.1, 0., 0.15])
+        h.add_rashba(0.2)
+        m = h.intra
+        assert h.is_sparse
+        md = np.asarray(m.todense()) if hasattr(m, "todense") else np.asarray(m)
+        assert np.all(np.isfinite(md)), setup

--- a/tests/hopping/test_kanemele_haldane_sparse.py
+++ b/tests/hopping/test_kanemele_haldane_sparse.py
@@ -1,0 +1,120 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula.kanemele import generalized_kane_mele, haldane, km_vector
+
+_sx = np.array([[0., 1.], [1., 0.]])
+_sy = np.array([[0., -1j], [1j, 0.]])
+_sz = np.array([[1., 0.], [0., -1.]])
+
+
+def _dense(m):
+    if isinstance(m, int): return np.zeros((0, 0), dtype=complex)
+    return np.asarray(m.todense()) if hasattr(m, "todense") else np.asarray(m)
+
+
+def _dense_reference_gkm(r1, r2, rm, fun, tol=1e-5):
+    """Independent O(N^2) dense reference for generalized_kane_mele, built
+    directly with the Pauli matrices without any of the KD-tree/vectorized
+    bond machinery in kanemele.generalized_kane_mele."""
+    r1 = np.array(r1); r2 = np.array(r2); rm = np.array(rm)
+    n = len(r1)
+    m = np.zeros((2 * n, 2 * n), dtype=complex)
+    for i in range(n):
+        for j in range(n):
+            dr = r1[i] - r2[j]
+            if not dr.dot(dr) < 4.1: continue
+            ur = km_vector(r1[i], r2[j], rm, tol=tol)
+            if ur[0] == 0.0 and ur[1] == 0.0 and ur[2] == 0.0: continue
+            r3 = (r1[i] + r2[j]) / 2.0
+            cv = fun(r3) if callable(fun) else fun
+            sm = 1j * (ur[0] * _sx + ur[1] * _sy + ur[2] * _sz) * cv
+            m[2 * i:2 * i + 2, 2 * j:2 * j + 2] = sm
+    return m
+
+
+def _dense_reference_haldane(r1, r2, rm, fun, sublattice=None):
+    """Independent O(N^2) dense reference for haldane."""
+    r1 = np.array(r1); r2 = np.array(r2); rm = np.array(rm)
+    n = len(r1)
+    if sublattice is None: sublattice = np.zeros(n) + 1.0
+    m = np.zeros((n, n), dtype=complex)
+    for i in range(n):
+        for j in range(n):
+            dr = r1[i] - r2[j]
+            if not dr.dot(dr) < 4.1: continue
+            ur = km_vector(r1[i], r2[j], rm)
+            if ur[2] == 0.0: continue
+            r3 = (r1[i] + r2[j]) / 2.0
+            cv = fun(r3) if callable(fun) else fun
+            m[i, j] = 1j * ur[2] * cv * (sublattice[i] + sublattice[j]) / 2.
+    return m
+
+
+def _geometries():
+    cases = {}
+    g = geometry.honeycomb_lattice().get_supercell(4)
+    cases["honeycomb"] = (g, g.r, g.r)
+    g = geometry.kagome_lattice().get_supercell(3)
+    cases["kagome"] = (g, g.r, g.r)
+    g = geometry.triangular_lattice().get_supercell(4)
+    cases["triangular"] = (g, g.r, g.r)
+    g = geometry.honeycomb_lattice().get_supercell(4)
+    cases["honeycomb_shifted"] = (g, g.r, [ir + g.a1 for ir in g.r])
+    return cases
+
+
+def test_generalized_kane_mele_matches_dense_reference():
+    """generalized_kane_mele (KD-tree candidate search + vectorized 2x2
+    spin-block construction) must match a fully independent dense O(N^2)
+    reference, for constant and position-dependent coupling strength."""
+    for name, (g, r1, r2) in _geometries().items():
+        rm = g.multireplicas(3)
+        got = _dense(generalized_kane_mele(r1, r2, rm, fun=0.15))
+        ref = _dense_reference_gkm(r1, r2, rm, 0.15)
+        assert np.max(np.abs(got - ref)) < 1e-8, name
+
+        got = _dense(generalized_kane_mele(r1, r2, rm,
+                fun=lambda p: 0.1 + 0.05 * p[0]))
+        ref = _dense_reference_gkm(r1, r2, rm, lambda p: 0.1 + 0.05 * p[0])
+        assert np.max(np.abs(got - ref)) < 1e-8, (name, "callable")
+
+
+def test_haldane_matches_dense_reference():
+    """haldane (sparse triplet construction instead of a dense nsites x
+    nsites array) must match a fully independent dense O(N^2) reference,
+    for constant/position-dependent strength and a sublattice pattern."""
+    for name, (g, r1, r2) in _geometries().items():
+        rm = g.multireplicas(3)
+        sub = getattr(g, "sublattice", None)
+        got = _dense(haldane(r1, r2, rm, fun=0.2, sublattice=sub))
+        ref = _dense_reference_haldane(r1, r2, rm, 0.2, sublattice=sub)
+        assert np.max(np.abs(got - ref)) < 1e-8, name
+
+        got = _dense(haldane(r1, r2, rm, fun=lambda p: 0.1 + 0.02 * p[1],
+                sublattice=sub))
+        ref = _dense_reference_haldane(r1, r2, rm, lambda p: 0.1 + 0.02 * p[1],
+                sublattice=sub)
+        assert np.max(np.abs(got - ref)) < 1e-8, (name, "callable")
+
+
+def test_add_soc_and_add_haldane_produce_finite_sparse_hamiltonians():
+    """End-to-end add_soc/add_haldane on 0D, 2D, and multicell 2D
+    Hamiltonians must stay finite and sparse."""
+    g = geometry.honeycomb_lattice()
+    for dim0 in [True, False]:
+        gg = g.get_supercell(4) if dim0 else g
+        if dim0: gg.dimensionality = 0
+        for multicell in [False, True]:
+            h = gg.get_hamiltonian(is_sparse=True, is_multicell=multicell)
+            h.add_soc(0.1)
+            m = h.intra
+            assert h.is_sparse
+            md = np.asarray(m.todense()) if hasattr(m, "todense") else np.asarray(m)
+            assert np.all(np.isfinite(md)), (dim0, multicell, "soc")
+
+            h2 = gg.get_hamiltonian(is_sparse=True, is_multicell=multicell)
+            h2.add_haldane(0.1)
+            m2 = h2.intra
+            md2 = np.asarray(m2.todense()) if hasattr(m2, "todense") else np.asarray(m2)
+            assert np.all(np.isfinite(md2)), (dim0, multicell, "haldane")

--- a/tests/hopping/test_kanemele_haldane_sparse.py
+++ b/tests/hopping/test_kanemele_haldane_sparse.py
@@ -98,6 +98,28 @@ def test_haldane_matches_dense_reference():
         assert np.max(np.abs(got - ref)) < 1e-8, (name, "callable")
 
 
+def test_haldane_captures_bonds_in_the_1_9_to_sqrt4_1_gap():
+    """haldane's candidate-site pre-filter radius must be >= sqrt(4.1) to
+    match its own dr.dot(dr)<4.1 acceptance test a few lines later. A
+    tighter radius (this used to be a literal d=1.9) silently drops any
+    genuine bond whose distance falls in (1.9, sqrt(4.1)) before the
+    acceptance test ever sees it -- not triggered by honeycomb/kagome/
+    triangular (their second-neighbor distances don't fall in that gap),
+    so engineer a 3-point geometry that does."""
+    pi = np.array([0., 0., 0.])
+    pm = np.array([1., 0., 0.])  # first neighbor of pi, distance 1
+    target_d = 1.95  # strictly inside (1.9, sqrt(4.1)=2.0248)
+    a = np.arccos((target_d ** 2 - 2) / 2.0)
+    pj = pm + np.array([np.cos(a), np.sin(a), 0.])
+    assert 1.9 < np.linalg.norm(pi - pj) < np.sqrt(4.1)
+
+    r1 = np.array([pi])
+    r2 = np.array([pj])
+    rm = np.array([pi, pm, pj])
+    m = haldane(r1, r2, rm, fun=0.3)
+    assert abs(np.asarray(m.todense())[0, 0]) > 1e-10
+
+
 def test_add_soc_and_add_haldane_produce_finite_sparse_hamiltonians():
     """End-to-end add_soc/add_haldane on 0D, 2D, and multicell 2D
     Hamiltonians must stay finite and sparse."""

--- a/tests/keldysh/test_kappa_finite_temperature.py
+++ b/tests/keldysh/test_kappa_finite_temperature.py
@@ -45,6 +45,25 @@ def test_get_kappa_finite_temperature_energies_does_not_recurse_or_reference_und
     assert len(calls) > 0 # the stub was actually reached, not just imported
 
 
+def test_get_kappa_finite_temperature_energies_accepts_caller_selfenergy_qtci(monkeypatch):
+    """branch_kappas builds its own extra={"selfenergy_qtci": shared} for
+    the superconducting branch and used to merge it into the call with
+    get_conductances_finite_temp(...,**extra,**kwargs) -- if the caller's
+    own kwargs already contained selfenergy_qtci (a real, documented
+    didv/dc_current kwarg), that raised "got multiple values for keyword
+    argument" instead of letting the freshly-built, branch-specific
+    interpolant take precedence."""
+    def fake_didv(self, energy=0.0, **kwargs):
+        return 1.0 + 0.01*abs(energy)
+    monkeypatch.setattr(heterostructures.Heterostructure, "didv", fake_didv)
+
+    HT = _sc_junction()
+    out = kappa_mod.get_kappa_finite_temperature_energies(
+        HT, energies=[0.05, 0.1], temp=0.02,
+        selfenergy_qtci={"caller": "value"})
+    assert np.all(np.isfinite(out))
+
+
 def test_shared_selfenergy_for_branch_only_builds_for_both_sc_leads():
     """_shared_selfenergy_for_branch is the piece that lets keldysh_didv's
     self-energy interpolant be reused across a whole finite-temperature

--- a/tests/keldysh/test_localprobe_keldysh.py
+++ b/tests/keldysh/test_localprobe_keldysh.py
@@ -116,3 +116,39 @@ def test_explicit_central_region_style_checks_still_apply():
     lp = LocalProbe(h, delta=1e-4)
     with pytest.raises(NotImplementedError):
         lp.get_dc_current(0.1)
+
+
+def test_didv_delta_default_matches_pre_refactor_number_when_unset():
+    """LocalProbe.didv's zero-temperature path used to call the bare
+    didv() function directly (its own hardcoded delta=1e-6 default,
+    ignoring self.delta entirely); routing through generic_didv (to fix
+    temp being silently swallowed, see test_kappa_finite_temperature.py)
+    made it default to self.delta instead -- a real, previously
+    unintended numerical change for anyone relying on the implicit
+    default. __init__'s own delta default is now also 1e-6, specifically
+    so a caller who never touches delta anywhere still gets exactly the
+    old number; a caller who *does* pass delta explicitly at construction
+    now sees it actually honored by didv() instead of silently ignored."""
+    from pyqula.transporttk.didv import didv as bare_didv
+    g = geometry.chain()
+    h = g.get_hamiltonian(); h.shift_fermi(1.); h.add_swave(0.1)
+    lead = geometry.chain().get_hamiltonian(); lead.shift_fermi(1.); lead.add_swave(0.1)
+    kwargs = dict(nmax=4, nmax_max=10, tol=1e-2)
+
+    # no delta anywhere -> identical to the old bare-didv(delta=1e-6) call
+    lp_default = LocalProbe(h, lead=lead)
+    lp_default.T = 0.3
+    v_new = lp_default.didv(energy=0.25, **kwargs)
+    v_bare = bare_didv(lp_default, energy=0.25, **kwargs)
+    assert abs(v_new - v_bare) < 1e-10
+
+    # explicit delta at construction must now actually reach didv()
+    lp_explicit = LocalProbe(h, lead=lead, delta=1e-3)
+    lp_explicit.T = 0.3
+    v_explicit = lp_explicit.didv(energy=0.25, **kwargs)
+    v_explicit_old_wrong = bare_didv(lp_explicit, energy=0.25, **kwargs)
+    assert abs(v_explicit - v_explicit_old_wrong) > 1e-6
+
+    # an explicit delta= passed straight to didv() still overrides everything
+    v_override = lp_explicit.didv(energy=0.25, delta=1e-6, **kwargs)
+    assert abs(v_override - v_explicit_old_wrong) < 1e-10


### PR DESCRIPTION
## Summary

Follow-on to #42 (already merged), which covered QPI's FFT convolution and KPM's fused Chebyshev recursion. This PR covers the remaining work from the same session:

### add_rashba: O(N log N) neighbor search + vectorized sparse construction
`rashba_matrix` built an nat x nat Python list-of-lists of 2x2 blocks for `scipy.sparse.bmat` regardless of sparsity (~1e10 object slots at nat~1e5). Neighbor search (`neighbor.find_first_neighbor`) was an O(N^2) all-pairs numba scan.
- `find_first_neighbor` -> `scipy.spatial.cKDTree` (O(N log N)).
- `rashba_matrix` builds sparse COO triplets directly from the bond list.
- Per-bond 2x2 spin block was still built via scipy-sparse Pauli-matrix arithmetic (profiling showed this dominates once the O(N^2) parts are gone) -- switched to dense numpy Pauli matrices, vectorized across all bonds.

Measured on a ~100k-site honeycomb flake: `rashba_matrix` alone 0.83s/408MB (old: O(N^2), not run at this size, extrapolates to tens of GB); full `add_rashba` end-to-end 1.48s/478MB.

### generalized_kane_mele/haldane (add_soc/add_haldane): same pattern, plus a dense-array crash and a third bottleneck
- `haldane` allocated a fully **dense** nsites x nsites complex128 array unconditionally, regardless of sparsity. At nsites~1e5 this is ~147 GiB and crashes outright -- confirmed: `numpy._core._exceptions.ArrayMemoryError: Unable to allocate 147. GiB`. Now builds sparse COO triplets from bonds directly.
- `generalized_kane_mele` had the same nsites x nsites Python list-of-blocks + `bmat` pattern -- fixed the same way, including vectorizing the per-bond 2x2 spin block construction.
- Both functions' neighbor searches (`neighbor.find_close_neighbors`, called once per site in a loop -- O(N^2) total) now go through a new `find_close_neighbors_batch`: one shared KD-tree, queried for every site at once.
- A third, unrelated bottleneck surfaced once the above were fixed: `add_kane_mele`/`add_haldane_like`'s own cell-enumeration loop calls `multicell.close_enough` once per candidate periodic-cell shift -- an O(len(rs1)*len(rs2)) numba double loop with an early exit for "yes, close" but not for "no, nothing is close" (routine for a distant cell shift), ~10s per call at ~1e4 sites. Replaced with a KD-tree nearest-neighbor query.

Measured at nsites=9800 (honeycomb, spinful): `generalized_kane_mele` alone 1.40s/327MB (old: 4.78s already at nsites=1800, O(N^2)); `haldane` alone 0.61s/327MB; `add_soc` end-to-end 2.19s/327MB (pre-fix: did not complete within 100s); `add_haldane` end-to-end 2.10s/327MB. At nsites=99458: `generalized_kane_mele` 10.1s/1.3GB, `haldane` 6.5s/1.3GB.

### Code-review fixes (from `/code-review` against the full branch diff)
- **haldane**: candidate-site pre-filter radius (`d=1.9`) was tighter than its own acceptance test (`dr.dot(dr)<4.1`, distance ~2.0248), silently dropping genuine bonds in that gap. Pre-existing (not introduced by this optimization, not triggered by honeycomb/kagome/triangular). Widened to `d=sqrt(4.1)` -- a strict superset, so it can only fix false negatives.
- **kappa.branch_kappas**: `get_conductances_finite_temp(...,**extra,**kwargs)` raised `TypeError: got multiple values for keyword argument` if the caller already passed `selfenergy_qtci`. Fixed via `dict.update`.
- **LocalProbe.didv**: an earlier refactor (before this PR, already merged in #41/#42) inadvertently changed the zero-temperature `delta` default from a hardcoded `1e-6` to `self.delta`, despite its docstring claiming no change -- confirmed ~1000x different results for an explicit `self.delta=1e-3` probe. Resolved (per discussion) by keeping the `self.delta` resolution (consistent with `Heterostructure.didv`) and changing `LocalProbe.__init__`'s own default from `1e-5` to `1e-6`, so untouched-delta callers get the exact old number while explicit-delta callers now get it correctly honored.

## Verification
- rashba: `find_first_neighbor` matches brute-force reference; `rashba_matrix` matches an independent dense O(N^2) reference (constant/position-dependent strength, non-z spin axis, edge-localized profile); `add_rashba` end-to-end verified finite on top of SOC/exchange.
- kanemele/haldane: verified against the old kanemele.py (loaded standalone from git history) bit-for-bit on honeycomb/kagome/triangular lattices, up to the practical ceiling for running the old O(N^2) code (~1800 sites); new tests check against independent dense/brute-force references; `add_soc`/`add_haldane` end-to-end verified finite on 0D/2D/multicell-2D Hamiltonians.
- Each code-review fix has a targeted regression test reproducing the original failure and confirming the fix.
- Full test suite: 279 passed.

## Test plan
- [x] All topic-specific test subsets run individually (see commit messages)
- [x] `python -m pytest tests` (full suite, 279 passed)

https://claude.ai/code/session_01PaAoiDzJuVjGZWgHRDU1GW