### PR TITLE
green: memoize adaptive Simpson recursion behind 2D adaptive self-energy

### DIFF
--- a/src/pyqula/integration.py
+++ b/src/pyqula/integration.py
@@ -33,24 +33,37 @@ def simpsons_rule(f,a,b):
     h3 = abs(b-a) / 6.0
     return h3*(f(a) + 4.0*f(c) + f(b))
  
-def recursive_asr(f,a,b,eps,whole):
-    "Recursive implementation of adaptive Simpson's rule."
+def recursive_asr(f,a,b,eps,whole,fa=None,fm=None,fb=None,test=None):
+    """Recursive implementation of adaptive Simpson's rule.
+
+    fa, fm, fb are f's already-known values at a, the midpoint and b (the
+    caller has always just computed them to build `whole`); each split
+    below then only evaluates the two genuinely new sub-midpoints instead
+    of re-deriving all three inherited points, which the naive version of
+    this recursion did on every call. For an expensive f (e.g. a
+    Sancho-Rubio renormalization solve, as used by the 2D adaptive
+    Green's function mode), that redundant re-evaluation measured ~3x
+    more solves than distinct points needed, growing with recursion depth.
+    """
+    if test is None: test = lambda d: np.max(np.abs(d))
     c = (a+b) / 2.0
-    left = simpsons_rule(f,a,c)
-    right = simpsons_rule(f,c,b)
-    if np.max(np.abs(left + right - whole)) <= 15*eps:
+    if fa is None: fa = f(a)
+    if fm is None: fm = f(c)
+    if fb is None: fb = f(b)
+    fd = f((a+c)/2.0) # new left-half midpoint
+    fe = f((c+b)/2.0) # new right-half midpoint
+    left  = (c-a)/6.0 * (fa + 4.0*fd + fm)
+    right = (b-c)/6.0 * (fm + 4.0*fe + fb)
+    if test(left + right - whole) <= 15*eps:
         return left + right + (left + right - whole)/15.0
-    return recursive_asr(f,a,c,eps/2.0,left) + recursive_asr(f,c,b,eps/2.0,right)
+    return (recursive_asr(f,a,c,eps/2.0,left, fa=fa,fm=fd,fb=fm,test=test) +
+            recursive_asr(f,c,b,eps/2.0,right,fa=fm,fm=fe,fb=fb,test=test))
 
 
-def recursive_asr_imag(f,a,b,eps,whole):
-    "Recursive implementation of adaptive Simpson's rule."
-    c = (a+b) / 2.0
-    left = simpsons_rule(f,a,c)
-    right = simpsons_rule(f,c,b)
-    if np.max(np.abs(np.imag(left + right - whole))) <= 15*eps:
-        return left + right + (left + right - whole)/15.0
-    return recursive_asr(f,a,c,eps/2.0,left) + recursive_asr(f,c,b,eps/2.0,right)
+def recursive_asr_imag(f,a,b,eps,whole,**kwargs):
+    "Adaptive Simpson's rule (see recursive_asr) converging on the imaginary part only."
+    return recursive_asr(f,a,b,eps,whole,
+                          test=lambda d: np.max(np.abs(np.imag(d))),**kwargs)
 
 
 
@@ -76,10 +89,13 @@ def scalar_asr(f,a,b,eps,whole):
  
 def adaptive_simpsons_rule(f,a,b,eps,only_imag=False):
     "Calculate integral of f from a to b with max error of eps."
+    c = (a+b) / 2.0
+    fa,fm,fb = f(a),f(c),f(b)
+    whole = (b-a)/6.0 * (fa + 4.0*fm + fb)
     if only_imag:
-      return recursive_asr_imag(f,a,b,eps,simpsons_rule(f,a,b))
+      return recursive_asr_imag(f,a,b,eps,whole,fa=fa,fm=fm,fb=fb)
     else:
-      return recursive_asr(f,a,b,eps,simpsons_rule(f,a,b))
+      return recursive_asr(f,a,b,eps,whole,fa=fa,fm=fm,fb=fb)
 
 
 


### PR DESCRIPTION
## Summary

`green.bloch_selfenergy(h, mode="adaptive")` for 2D systems integrates over kx with `integration.adaptive_simpsons_rule`, calling `green_kchain` (a Sancho-Rubio renormalization solve) at every quadrature node — a much more expensive `f` than this recursion was designed around. `recursive_asr` only passed the combined Simpson estimate (`whole`) into its recursive calls, not the individual `f(a)`, `f(midpoint)`, `f(b)` values used to build it, so every split re-evaluated all three inherited points from scratch and only needed 2 of its 5 evaluations to be new.

Fixed by threading `(fa, fm, fb)` down through `recursive_asr`/`recursive_asr_imag` instead of recomputing them. Same acceptance criterion and eps-halving as before — this changes which points get *evaluated twice*, not which get accepted, so output is unchanged.

**Side effect:** also fixes `recursive_asr_imag`'s recursive step, which called `recursive_asr` (the full-complex-error criterion) instead of itself — silently switching convergence tests after the first split. Currently unreachable in this repo (no caller passes `only_imag=True`), but no longer latent now that this function was being rewritten anyway.

**Left out of scope:** `scalar_asr`/`simpson()` (used by `transporttk.didv`'s `imode="simpson"` path) has the identical structural inefficiency but is a separate call site — not touched here.

## Measured

On the real `green_kchain` integrand (Rashba+Zeeman honeycomb), sweeping the quadrature tolerance with delta=1e-3 fixed:

| eps | calls before | distinct (=calls after) | waste before |
|---|---|---|---|
| 1e-2 | 45 | 17 | 2.65x |
| 1e-3 | 117 | 41 | 2.85x |
| 1e-4 | 237 | 81 | 2.93x |
| 1e-5 | 405 | 137 | 2.96x |

Waste converges to ~3x independent of delta and the tolerance — structural, not a corner case. On a 144-orbital supercell (25-45ms per solve), this showed up directly in wall time: 0.53s → 0.24s per self-energy call at eps=1e-3 (~2.2x).

## Verification
- Bit-for-bit identical output vs. the old implementation: synthetic matrix-valued test function (several tolerances, plus the `only_imag=True` path) and the real `green_kchain` integrand — `max|old-new|` = 0.0 in every case.
- Redundant-call count: 0% waste after the fix (was 62-66%), confirmed across eps=1e-2..1e-5.
- `tests/green`: 37 passed.
- Full suite: 295 passed, 0 failed.

## Test plan
- [x] `python -m pytest tests/green` — 37 passed
- [x] `python -m pytest tests` (full suite) — 295 passed, 0 failed
- [x] Bit-for-bit output comparison against the pre-fix implementation (synthetic + real integrand, multiple tolerances, both convergence modes)
- [x] Direct call-count instrumentation confirming 0% redundant evaluation post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAoiDzJuVjGZWgHRDU1GW