### PR TITLE
Add mean-field for spin-spin (SzSz/SxSx/SySy) exchange interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ From the [Jyvaskyla Summer School 2022](https://github.com/joselado/jyvaskyla_su
 ## Interacting mean-field Hamiltonians ##
 - Selfconsistent mean-field calculations with local/non-local interactions
 - Both collinear and non-collinear formalism
-- Direct spin-spin (Heisenberg-like) exchange mean field, SzSz/SxSx/SySy and combined anisotropic exchange
+- Direct spin-spin (Heisenberg-like) exchange mean field, SzSz/SxSx/SySy and combined anisotropic exchange, simultaneously with density-density interactions
 - Anomalous mean-field for non-collinear superconductors
 - Full selfconsistency with all Wick terms for non-collinear superconductors
 - Constrained and unconstrained mean-field calculations

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ From the [Jyvaskyla Summer School 2022](https://github.com/joselado/jyvaskyla_su
 ## Interacting mean-field Hamiltonians ##
 - Selfconsistent mean-field calculations with local/non-local interactions
 - Both collinear and non-collinear formalism
+- Direct spin-spin (Heisenberg-like) exchange mean field, SzSz/SxSx/SySy and combined anisotropic exchange
 - Anomalous mean-field for non-collinear superconductors
 - Full selfconsistency with all Wick terms for non-collinear superconductors
 - Constrained and unconstrained mean-field calculations

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -909,6 +909,14 @@ h = h.get_exchange_mean_field_hamiltonian(Jz1=-1.0,Jx1=-0.5,
                                             filling=0.2,mf="ferroZ")
 ```
 
+Density-density interactions ($U$/$V_1$/$V_2$/$V_3$/$V_r$, as in `get_mean_field_hamiltonian`) and spin-spin exchange ($J_x$/$J_y$/$J_z$, as above) can also be solved together, self-consistently, in a single combined SCF loop with `h.get_combined_mean_field_hamiltonian(U=...,V1=...,Jz1=...,...)`. This is not new physics: $S^z_iS^z_j$ and a density-density interaction are both density-density interactions in the spin-orbital basis (just with a different sign pattern across the four spin blocks), and the Hartree-Fock decoupling is linear in the interaction, so the density-density contribution is simply added into the same $z$-channel matrix the $J_z$ term already uses, with the $J_x$/$J_y$ channels handled exactly as above
+
+```python
+h = g.get_hamiltonian(has_spin=True)
+h = h.get_combined_mean_field_hamiltonian(U=5.0,Jz1=-1.0,
+                                            filling=0.2,mf="ferroZ")
+```
+
 
 # Spatially resolved density of states
 
@@ -1724,6 +1732,19 @@ Optional arguments:
 
 - Jx1, Jx2, Jx3, Jy1, Jy2, Jy3, Jz1, Jz2, Jz3 = 0.: first/second/third-neighbor couplings for each axis
 - Jxr, Jyr, Jzr=None: general distance-dependent couplings, one per axis
+- mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
+
+Returns the converged Hamiltonian (or `None` if the SCF did not converge)
+
+### h.get_combined_mean_field_hamiltonian()
+Self-consistent mean field combining density-density interactions
+(onsite $U$, $V_1$/$V_2$/$V_3$/$V_r$ neighbor-shell) with anisotropic
+spin-spin exchange ($J_x$/$J_y$/$J_z$) in a single SCF loop.
+
+Optional arguments:
+
+- U, V1, V2, V3, Vr: as in `get_mean_field_hamiltonian`
+- Jx1, Jx2, Jx3, Jy1, Jy2, Jy3, Jz1, Jz2, Jz3, Jxr, Jyr, Jzr: as in `get_exchange_mean_field_hamiltonian`
 - mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
 
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -909,7 +909,7 @@ h = h.get_exchange_mean_field_hamiltonian(Jz1=-1.0,Jx1=-0.5,
                                             filling=0.2,mf="ferroZ")
 ```
 
-Density-density interactions ($U$/$V_1$/$V_2$/$V_3$/$V_r$, as in `get_mean_field_hamiltonian`) and spin-spin exchange can also be solved together, self-consistently, in a single combined SCF loop with `h.get_combined_mean_field_hamiltonian(U=...,V1=...,J1=...,...)`. This is not new physics: a density-density interaction and $S^z_iS^z_j$ are both density-density interactions in the spin-orbital basis (just with a different sign pattern across the four spin blocks), and the Hartree-Fock decoupling is linear in the interaction, so the density-density contribution is simply added into the same $z$-channel matrix the exchange term already uses. Exchange here follows a $V_1$/$V_2$/$V_3$-like convention: $J_1$/$J_2$/$J_3$ ($+J_r$) are isotropic Heisenberg couplings, $J(S^x_iS^x_j+S^y_iS^y_j+S^z_iS^z_j)$, for the first/second/third neighbor shells, and $J_x$/$J_y$/$J_z$ are an optional anisotropic correction added on top of $J_1$ for the first-neighbor shell only (e.g. the effective first-neighbor $J_z$ coupling is $J_1+J_z$); all default to 0
+Density-density interactions ($U$/$V_1$/$V_2$/$V_3$/$V_r$, as in `get_mean_field_hamiltonian`) and spin-spin exchange can also be solved together, self-consistently, in a single combined SCF loop with `h.get_combined_mean_field_hamiltonian(U=...,V1=...,J1=...,...)`. This is not new physics: a density-density interaction and $S^z_iS^z_j$ are both density-density interactions in the spin-orbital basis (just with a different sign pattern across the four spin blocks), and the Hartree-Fock decoupling is linear in the interaction, so the density-density contribution is simply added into the same $z$-channel matrix the exchange term already uses. Exchange here follows a $V_1$/$V_2$/$V_3$-like convention: $J_1$/$J_2$/$J_3$ ($+J_r$) are isotropic Heisenberg couplings, $J(S^x_iS^x_j+S^y_iS^y_j+S^z_iS^z_j)$, for the first/second/third neighbor shells, and $J_{1x}$/$J_{1y}$/$J_{1z}$ are an optional anisotropic correction added on top of $J_1$ for the first-neighbor shell only (e.g. the effective first-neighbor $J_z$ coupling is $J_1+J_{1z}$); all default to 0
 
 ```python
 h = g.get_hamiltonian(has_spin=True)
@@ -1746,7 +1746,7 @@ Optional arguments:
 - U, V1, V2, V3, Vr: as in `get_mean_field_hamiltonian`
 - J1, J2, J3 = 0.: isotropic Heisenberg exchange for the first/second/third-neighbor shells (same shell convention as V1/V2/V3)
 - Jr=None: general distance-dependent isotropic exchange function, as `Vr`
-- Jx, Jy, Jz = 0.: optional anisotropic correction added to J1 on the first-neighbor shell only (e.g. the effective first-neighbor Jz coupling is J1+Jz); second/third neighbors stay purely isotropic
+- J1x, J1y, J1z = 0.: optional anisotropic correction added to J1 on the first-neighbor shell only (e.g. the effective first-neighbor Jz coupling is J1+J1z); second/third neighbors stay purely isotropic
 - mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
 
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -917,6 +917,16 @@ h = h.get_combined_mean_field_hamiltonian(U=5.0,J1=-1.0,
                                             filling=0.2,mf="ferroZ")
 ```
 
+All of the spin-spin exchange functions above also work on BdG (Nambu) Hamiltonians (`h.turn_nambu()`/`h.setup_nambu_spinor()`). `get_szsz_mean_field_hamiltonian`/`get_sxsx_mean_field_hamiltonian`/`get_sysy_mean_field_hamiltonian` need no special handling: `get_mean_field_hamiltonian`'s existing Hartree-Fock-plus-anomalous decoupling already dispatches generically for any density-density-shaped interaction, including $S^z_iS^z_j$'s. `get_combined_mean_field_hamiltonian`/`get_exchange_mean_field_hamiltonian` decouple the exchange ($J$) channels in the normal (electron) sector only for a Nambu Hamiltonian -- exchange does not itself induce superconducting pairing here, only $U$/$V_1$/$V_2$/$V_3$ can (the same mechanism as the spin-triplet example above); a state with both magnetic and superconducting order can still emerge from combining an exchange field with an attractive $V_1$:
+
+```python
+h = g.get_hamiltonian(has_spin=True)
+h.add_exchange([0.,0.,0.3])
+h.turn_nambu()
+h = h.get_combined_mean_field_hamiltonian(V1=-1.0,J1z=-0.3,
+                                            filling=0.3,mf="random")
+```
+
 
 # Spatially resolved density of states
 
@@ -1716,13 +1726,19 @@ Optional arguments:
 - filling, mf, nk, maxerror, mix, constrains: as in `get_mean_field_hamiltonian`
 - return_total_energy=False: also return the total energy
 
+Also works on BdG (Nambu) Hamiltonians, decoupling both the normal and
+anomalous (pairing) channels (same generic dispatch `get_mean_field_hamiltonian`
+already uses).
+
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)
 
 ### h.get_sxsx_mean_field_hamiltonian() / h.get_sysy_mean_field_hamiltonian()
 Same as `get_szsz_mean_field_hamiltonian()`, for a $S^x_iS^x_j$ /
 $S^y_iS^y_j$ interaction instead, implemented by rotating the problem so
 that x (or y) becomes the computational z axis, solving there, and
-rotating the converged Hamiltonian back.
+rotating the converged Hamiltonian back. Also works on BdG Hamiltonians:
+`rotate_spin.global_spin_rotation` already rotates the Nambu-doubled
+Hamiltonian correctly with no changes needed.
 
 ### h.get_exchange_mean_field_hamiltonian()
 Self-consistent anisotropic exchange mean field, combining
@@ -1733,6 +1749,11 @@ Optional arguments:
 - Jx1, Jx2, Jx3, Jy1, Jy2, Jy3, Jz1, Jz2, Jz3 = 0.: first/second/third-neighbor couplings for each axis
 - Jxr, Jyr, Jzr=None: general distance-dependent couplings, one per axis
 - mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
+
+Also works on BdG Hamiltonians, but decouples the exchange interaction in
+the normal (electron) sector only -- it does not itself induce
+superconducting pairing (see `get_combined_mean_field_hamiltonian`, where
+$V_1$ can).
 
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)
 
@@ -1747,6 +1768,13 @@ Optional arguments:
 - J1, J2, J3 = 0.: isotropic Heisenberg exchange for the first/second/third-neighbor shells (same shell convention as V1/V2/V3)
 - Jr=None: general distance-dependent isotropic exchange function, as `Vr`
 - J1x, J1y, J1z = 0.: optional anisotropic correction added to J1 on the first-neighbor shell only (e.g. the effective first-neighbor Jz coupling is J1+J1z); second/third neighbors stay purely isotropic
+
+On a BdG Hamiltonian, $U$/$V_1$/$V_2$/$V_3$/$V_r$ keep the full
+normal+anomalous (pairing) treatment (identical to
+`get_mean_field_hamiltonian`), while the exchange ($J$) channels are
+decoupled in the normal sector only -- so a state with both magnetic and
+superconducting order requires an attractive $V$, not $J$, to seed the
+pairing (see the example above).
 - mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
 
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -871,6 +871,45 @@ h.get_kdos_bands(operator="electron",nk=400,
 ```
 
 
+## Spin-spin exchange interactions
+
+The interactions considered above are all of density-density type, $c^\dagger_{i,s}c_{i,s}c^\dagger_{j,s'}c_{j,s'}$. A different kind of interaction, relevant for localized-moment magnetism, is a direct spin-spin coupling $\vec{S}_i\cdot\vec{S}_j$ between the (Pauli) spin operators at two sites,
+
+$$
+H = J_z\sum_{\langle ij\rangle} S^z_i S^z_j
++ J_x\sum_{\langle ij\rangle} S^x_i S^x_j
++ J_y\sum_{\langle ij\rangle} S^y_i S^y_j
+$$
+
+with $J>0$ the antiferromagnetic (Heisenberg) sign convention and $J<0$ favoring a ferromagnetic instability. Writing $S^z_i=(n_{i,\uparrow}-n_{i,\downarrow})/2$,
+
+$$
+S^z_i S^z_j = \tfrac14\left(
+n_{i,\uparrow}n_{j,\uparrow} - n_{i,\uparrow}n_{j,\downarrow}
+- n_{i,\downarrow}n_{j,\uparrow} + n_{i,\downarrow}n_{j,\downarrow}
+\right)
+$$
+
+is already a density-density interaction between spin-orbitals, so $S^z_iS^z_j$ is solved with exactly the same Hartree-Fock machinery as the $U$/$V_1$/$V_2$/$V_3$ interactions above -- `h.get_szsz_mean_field_hamiltonian(J1=...)` (first-neighbor $J_z$; `J2`/`J3` add second/third neighbors, `Jr` a general distance-dependent coupling, following the same convention as `V1`/`V2`/`V3`/`Vr` in `get_mean_field_hamiltonian`). $S^x_iS^x_j$ and $S^y_iS^y_j$ are obtained by a global spin rotation that maps the $x$ (or $y$) axis onto the computational $z$ axis, solving the $S^zS^z$ problem there, and rotating the converged Hamiltonian back -- `h.get_sxsx_mean_field_hamiltonian(...)` and `h.get_sysy_mean_field_hamiltonian(...)`. Because the bare interaction is SU(2)-symmetric, the converged total energy of `SzSz`, `SxSx` and `SySy` at the same coupling only differs by which axis the moment orders along.
+
+```python
+from pyqula import geometry
+g = geometry.chain() # a chain, prone to ferromagnetic order away from half filling
+h = g.get_hamiltonian(has_spin=True)
+h = h.get_szsz_mean_field_hamiltonian(J1=-2.0,filling=0.2,
+                                       mf="ferroZ") # ferromagnetic Sz-Sz coupling
+m = h.get_magnetization() # uniform moment along z
+```
+
+The three channels can also be combined into a single anisotropic-exchange SCF loop, `h.get_exchange_mean_field_hamiltonian(Jx1=...,Jy1=...,Jz1=...)`, which decouples the $z$ channel directly and the $x$/$y$ channels through the same rotate-solve-rotate-back trick, each SCF iteration:
+
+```python
+h = g.get_hamiltonian(has_spin=True)
+h = h.get_exchange_mean_field_hamiltonian(Jz1=-1.0,Jx1=-0.5,
+                                            filling=0.2,mf="ferroZ")
+```
+
+
 # Spatially resolved density of states
 
 ```python
@@ -1656,6 +1695,38 @@ Optional arguments:
 - symmetries=None: `"auto"` to auto-detect and enforce the point group, or an explicit list of `symmetrytk.pointgroup.SymmetryOperation`
 
 Returns a new, smaller Hamiltonian; `.wannier_centres`, `.wannier_spreads` and `.wannier_spread_total` hold the Wannier-function geometry
+
+### h.get_szsz_mean_field_hamiltonian()
+Self-consistent Hartree-Fock mean field for a $J_z\sum S^z_iS^z_j$
+spin-spin exchange interaction (see "Spin-spin exchange interactions").
+$J>0$ is antiferromagnetic, $J<0$ ferromagnetic.
+
+Optional arguments:
+
+- J1, J2, J3 = 0.: first/second/third-neighbor $J_z$ couplings
+- Jr=None: general distance-dependent coupling function, as `Vr` for `get_mean_field_hamiltonian`
+- filling, mf, nk, maxerror, mix, constrains: as in `get_mean_field_hamiltonian`
+- return_total_energy=False: also return the total energy
+
+Returns the converged Hamiltonian (or `None` if the SCF did not converge)
+
+### h.get_sxsx_mean_field_hamiltonian() / h.get_sysy_mean_field_hamiltonian()
+Same as `get_szsz_mean_field_hamiltonian()`, for a $S^x_iS^x_j$ /
+$S^y_iS^y_j$ interaction instead, implemented by rotating the problem so
+that x (or y) becomes the computational z axis, solving there, and
+rotating the converged Hamiltonian back.
+
+### h.get_exchange_mean_field_hamiltonian()
+Self-consistent anisotropic exchange mean field, combining
+$J_x S^x_iS^x_j + J_yS^y_iS^y_j + J_zS^z_iS^z_j$ in a single SCF loop.
+
+Optional arguments:
+
+- Jx1, Jx2, Jx3, Jy1, Jy2, Jy3, Jz1, Jz2, Jz3 = 0.: first/second/third-neighbor couplings for each axis
+- Jxr, Jyr, Jzr=None: general distance-dependent couplings, one per axis
+- mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
+
+Returns the converged Hamiltonian (or `None` if the SCF did not converge)
 
 ## Heterostructure functions and methods
 

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -909,11 +909,11 @@ h = h.get_exchange_mean_field_hamiltonian(Jz1=-1.0,Jx1=-0.5,
                                             filling=0.2,mf="ferroZ")
 ```
 
-Density-density interactions ($U$/$V_1$/$V_2$/$V_3$/$V_r$, as in `get_mean_field_hamiltonian`) and spin-spin exchange ($J_x$/$J_y$/$J_z$, as above) can also be solved together, self-consistently, in a single combined SCF loop with `h.get_combined_mean_field_hamiltonian(U=...,V1=...,Jz1=...,...)`. This is not new physics: $S^z_iS^z_j$ and a density-density interaction are both density-density interactions in the spin-orbital basis (just with a different sign pattern across the four spin blocks), and the Hartree-Fock decoupling is linear in the interaction, so the density-density contribution is simply added into the same $z$-channel matrix the $J_z$ term already uses, with the $J_x$/$J_y$ channels handled exactly as above
+Density-density interactions ($U$/$V_1$/$V_2$/$V_3$/$V_r$, as in `get_mean_field_hamiltonian`) and spin-spin exchange can also be solved together, self-consistently, in a single combined SCF loop with `h.get_combined_mean_field_hamiltonian(U=...,V1=...,J1=...,...)`. This is not new physics: a density-density interaction and $S^z_iS^z_j$ are both density-density interactions in the spin-orbital basis (just with a different sign pattern across the four spin blocks), and the Hartree-Fock decoupling is linear in the interaction, so the density-density contribution is simply added into the same $z$-channel matrix the exchange term already uses. Exchange here follows a $V_1$/$V_2$/$V_3$-like convention: $J_1$/$J_2$/$J_3$ ($+J_r$) are isotropic Heisenberg couplings, $J(S^x_iS^x_j+S^y_iS^y_j+S^z_iS^z_j)$, for the first/second/third neighbor shells, and $J_x$/$J_y$/$J_z$ are an optional anisotropic correction added on top of $J_1$ for the first-neighbor shell only (e.g. the effective first-neighbor $J_z$ coupling is $J_1+J_z$); all default to 0
 
 ```python
 h = g.get_hamiltonian(has_spin=True)
-h = h.get_combined_mean_field_hamiltonian(U=5.0,Jz1=-1.0,
+h = h.get_combined_mean_field_hamiltonian(U=5.0,J1=-1.0,
                                             filling=0.2,mf="ferroZ")
 ```
 
@@ -1738,13 +1738,15 @@ Returns the converged Hamiltonian (or `None` if the SCF did not converge)
 
 ### h.get_combined_mean_field_hamiltonian()
 Self-consistent mean field combining density-density interactions
-(onsite $U$, $V_1$/$V_2$/$V_3$/$V_r$ neighbor-shell) with anisotropic
-spin-spin exchange ($J_x$/$J_y$/$J_z$) in a single SCF loop.
+(onsite $U$, $V_1$/$V_2$/$V_3$/$V_r$ neighbor-shell) with spin-spin
+exchange in a single SCF loop.
 
 Optional arguments:
 
 - U, V1, V2, V3, Vr: as in `get_mean_field_hamiltonian`
-- Jx1, Jx2, Jx3, Jy1, Jy2, Jy3, Jz1, Jz2, Jz3, Jxr, Jyr, Jzr: as in `get_exchange_mean_field_hamiltonian`
+- J1, J2, J3 = 0.: isotropic Heisenberg exchange for the first/second/third-neighbor shells (same shell convention as V1/V2/V3)
+- Jr=None: general distance-dependent isotropic exchange function, as `Vr`
+- Jx, Jy, Jz = 0.: optional anisotropic correction added to J1 on the first-neighbor shell only (e.g. the effective first-neighbor Jz coupling is J1+Jz); second/third neighbors stay purely isotropic
 - mf, filling, nk, maxerror, mix, constrains: as above (only `integration="ed"` and the plain-mixing solver are supported)
 
 Returns the converged Hamiltonian (or `None` if the SCF did not converge)

--- a/src/pyqula/hamiltonians.py
+++ b/src/pyqula/hamiltonians.py
@@ -25,6 +25,7 @@ from . import bandstructure
 from . import increase_hilbert
 from .meanfield import Vinteraction
 from .meanfield import Vinteraction_kpm
+from .meanfield import SzSz,SxSx,SySy,Jinteraction
 from .sctk import dvector
 from .algebratk import hamiltonianalgebra
 from .bandstructure import get_bands_nd
@@ -465,6 +466,34 @@ class Hamiltonian():
         through Chebyshev recursion on H(k). Meant for large/sparse
         Hamiltonians; see selfconsistency.densitydensity_kpm."""
         scf = Vinteraction_kpm(self,**kwargs)
+        if not scf.converged: scf.hamiltonian = None # no convergence
+        if return_total_energy:
+            return (scf.hamiltonian,scf.total_energy)
+        else: return scf.hamiltonian
+    @get_docstring(SzSz)
+    def get_szsz_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
+        scf = SzSz(self,**kwargs)
+        if not scf.converged: scf.hamiltonian = None # no convergence
+        if return_total_energy:
+            return (scf.hamiltonian,scf.total_energy)
+        else: return scf.hamiltonian
+    @get_docstring(SxSx)
+    def get_sxsx_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
+        scf = SxSx(self,**kwargs)
+        if not scf.converged: scf.hamiltonian = None # no convergence
+        if return_total_energy:
+            return (scf.hamiltonian,scf.total_energy)
+        else: return scf.hamiltonian
+    @get_docstring(SySy)
+    def get_sysy_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
+        scf = SySy(self,**kwargs)
+        if not scf.converged: scf.hamiltonian = None # no convergence
+        if return_total_energy:
+            return (scf.hamiltonian,scf.total_energy)
+        else: return scf.hamiltonian
+    @get_docstring(Jinteraction)
+    def get_exchange_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
+        scf = Jinteraction(self,**kwargs)
         if not scf.converged: scf.hamiltonian = None # no convergence
         if return_total_energy:
             return (scf.hamiltonian,scf.total_energy)

--- a/src/pyqula/hamiltonians.py
+++ b/src/pyqula/hamiltonians.py
@@ -44,6 +44,19 @@ from .htk import symmetry
 from .limits import densedimension as maxmatrix
 optimal = False
 
+def _mean_field_scf_result(scf,return_total_energy):
+    """Shared tail for the get_*_mean_field_hamiltonian wrappers below:
+    SzSz/SxSx/SySy return the NotImplemented sentinel (not an SCF object)
+    for spinless/BdG Hamiltonians, which must be checked before touching
+    scf.converged."""
+    if scf is NotImplemented:
+        if return_total_energy: return (None,None)
+        else: return None
+    if not scf.converged: scf.hamiltonian = None # no convergence
+    if return_total_energy:
+        return (scf.hamiltonian,scf.total_energy)
+    else: return scf.hamiltonian
+
 class Hamiltonian():
     """ Class for a hamiltonian """
     def __add__(self,h):  return hamiltonianalgebra.add(self,h)
@@ -472,32 +485,16 @@ class Hamiltonian():
         else: return scf.hamiltonian
     @get_docstring(SzSz)
     def get_szsz_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
-        scf = SzSz(self,**kwargs)
-        if not scf.converged: scf.hamiltonian = None # no convergence
-        if return_total_energy:
-            return (scf.hamiltonian,scf.total_energy)
-        else: return scf.hamiltonian
+        return _mean_field_scf_result(SzSz(self,**kwargs),return_total_energy)
     @get_docstring(SxSx)
     def get_sxsx_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
-        scf = SxSx(self,**kwargs)
-        if not scf.converged: scf.hamiltonian = None # no convergence
-        if return_total_energy:
-            return (scf.hamiltonian,scf.total_energy)
-        else: return scf.hamiltonian
+        return _mean_field_scf_result(SxSx(self,**kwargs),return_total_energy)
     @get_docstring(SySy)
     def get_sysy_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
-        scf = SySy(self,**kwargs)
-        if not scf.converged: scf.hamiltonian = None # no convergence
-        if return_total_energy:
-            return (scf.hamiltonian,scf.total_energy)
-        else: return scf.hamiltonian
+        return _mean_field_scf_result(SySy(self,**kwargs),return_total_energy)
     @get_docstring(Jinteraction)
     def get_exchange_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
-        scf = Jinteraction(self,**kwargs)
-        if not scf.converged: scf.hamiltonian = None # no convergence
-        if return_total_energy:
-            return (scf.hamiltonian,scf.total_energy)
-        else: return scf.hamiltonian
+        return _mean_field_scf_result(Jinteraction(self,**kwargs),return_total_energy)
     def get_tails(self,discard=None):
         """Write the tails of the wavefunctions"""
         if self.dimensionality!=0: raise

--- a/src/pyqula/hamiltonians.py
+++ b/src/pyqula/hamiltonians.py
@@ -25,7 +25,7 @@ from . import bandstructure
 from . import increase_hilbert
 from .meanfield import Vinteraction
 from .meanfield import Vinteraction_kpm
-from .meanfield import SzSz,SxSx,SySy,Jinteraction
+from .meanfield import SzSz,SxSx,SySy,Jinteraction,VJinteraction
 from .sctk import dvector
 from .algebratk import hamiltonianalgebra
 from .bandstructure import get_bands_nd
@@ -495,6 +495,9 @@ class Hamiltonian():
     @get_docstring(Jinteraction)
     def get_exchange_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
         return _mean_field_scf_result(Jinteraction(self,**kwargs),return_total_energy)
+    @get_docstring(VJinteraction)
+    def get_combined_mean_field_hamiltonian(self,return_total_energy=False,**kwargs):
+        return _mean_field_scf_result(VJinteraction(self,**kwargs),return_total_energy)
     def get_tails(self,discard=None):
         """Write the tails of the wavefunctions"""
         if self.dimensionality!=0: raise

--- a/src/pyqula/meanfield.py
+++ b/src/pyqula/meanfield.py
@@ -505,3 +505,4 @@ SzSz = spinspin.SzSz
 SxSx = spinspin.SxSx
 SySy = spinspin.SySy
 Jinteraction = spinspin.Jinteraction
+VJinteraction = spinspin.VJinteraction

--- a/src/pyqula/meanfield.py
+++ b/src/pyqula/meanfield.py
@@ -498,3 +498,10 @@ hubbardscf_kpm = densitydensity_kpm.hubbard_kpm
 Vinteraction_kpm = densitydensity_kpm.Vinteraction_kpm
 
 from .selfconsistency.potentials import keldysh
+
+from .selfconsistency import spinspin
+
+SzSz = spinspin.SzSz
+SxSx = spinspin.SxSx
+SySy = spinspin.SySy
+Jinteraction = spinspin.Jinteraction

--- a/src/pyqula/rotate_spin.py
+++ b/src/pyqula/rotate_spin.py
@@ -113,10 +113,19 @@ def spiralhopping(m,ri,rj,svector = np.array([0.,0.,1.]),
 
 
 def hamiltonian_spin_rotation(self,vector=np.array([0.,0.,1.]),angle=0.):
-    """ Perform a global spin rotation """
+    """ Perform a global spin rotation.
+
+    Also correct for BdG (Nambu, has_eh=True) Hamiltonians: pyqula's Nambu
+    convention (sctk/reorder.py's block2nambu) groups each site's electron
+    pair and hole pair as consecutive (up,down)-like 2-blocks, so
+    global_spin_rotation's n=m.shape[0]//2, kron(eye(n),rot) construction
+    already applies the same rotation to every one of those blocks
+    (electron pair and hole pair alike) with no changes needed -- verified
+    numerically (eigenvalue-preserving, and matches rotating the physical
+    exchange/pairing directly) against Hamiltonians with both an exchange
+    field and s-wave pairing present. """
     if not self.has_spin: raise # no spin in the Hamiltonian
     gsr = global_spin_rotation # rename method
-    if self.has_eh: raise
     self.intra = gsr(self.intra,vector=vector,angle=angle)
     if self.is_multicell: # multicell hamiltonian
       for i in range(len(self.hopping)): # loop 

--- a/src/pyqula/rotate_spin.py
+++ b/src/pyqula/rotate_spin.py
@@ -50,28 +50,19 @@ def align_magnetism(m,vectors):
 def global_spin_rotation(m,vector = np.array([0.,0.,1.]),angle = 0.0,
                              spiral = False,atoms = None):
   """ Rotates a matrix along a certain qvector """
-  # pauli matrices
-  from scipy.sparse import csc_matrix,bmat
-  iden = csc_matrix([[1.,0.],[0.,1.]])
   n = m.shape[0]//2 # number of sites
-  if atoms==None: 
-    atoms = range(n) # all the atoms
-  else: 
-    raise
-  R = [[None for i in range(n)] for j in range(n)] # rotation matrix
-  for i in range(n): # loop over sites
-      u = np.array(vector) # rotation direction
-      u = u/np.sqrt(u.dot(u)) # normalize rotation direction
-      rot = (u[0]*sx + u[1]*sy + u[2]*sz)/2. # rotation
-      # a factor 2 is taken out due to 1/2 of S
-      # a factor 2 is added to have BZ in the interval 0,1
-      rot = algebra.todense(rot)
-      rot = lg.expm(2.*np.pi*1j*rot*angle/2.0)
-  #    if i in atoms:
-      R[i][i] = rot  # save term
-#    else:
-#      R[i][i] = iden  # save term
-  R = bmat(R)  # convert to full sparse matrix
+  if atoms is not None: raise # per-atom rotation not implemented
+  u = np.array(vector) # rotation direction
+  u = u/np.sqrt(u.dot(u)) # normalize rotation direction
+  rot = (u[0]*sx + u[1]*sy + u[2]*sz)/2. # rotation
+  # a factor 2 is taken out due to 1/2 of S
+  # a factor 2 is added to have BZ in the interval 0,1
+  rot = algebra.todense(rot)
+  rot = lg.expm(2.*np.pi*1j*rot*angle/2.0)
+  # same rotation at every site, so this is just a repeated block-diagonal;
+  # np.kron avoids scipy.sparse.bmat, which mishandles the n=1 (single
+  # site per cell) case (raises "blocks must be 2-D")
+  R = np.kron(np.eye(n),rot) # full rotation matrix
   if spiral:  # for spin spiral
     mout = R @ m  # rotate matrix
   else:  # normal global rotation

--- a/src/pyqula/rotate_spin.py
+++ b/src/pyqula/rotate_spin.py
@@ -47,11 +47,13 @@ def align_magnetism(m,vectors):
 
 
 
-def global_spin_rotation(m,vector = np.array([0.,0.,1.]),angle = 0.0,
-                             spiral = False,atoms = None):
-  """ Rotates a matrix along a certain qvector """
-  n = m.shape[0]//2 # number of sites
-  if atoms is not None: raise # per-atom rotation not implemented
+def build_rotation_matrix(n,vector = np.array([0.,0.,1.]),angle = 0.0):
+  """ Build the full n-site block-diagonal spin rotation matrix for a
+  global spin rotation by `angle` about `vector` (same convention as
+  global_spin_rotation, which uses this internally). Split out so that a
+  caller applying the *same* fixed rotation to many matrices (e.g. every
+  iteration of an SCF loop) can build R once and reuse it, instead of
+  recomputing the matrix exponential on every call. """
   u = np.array(vector) # rotation direction
   u = u/np.sqrt(u.dot(u)) # normalize rotation direction
   rot = (u[0]*sx + u[1]*sy + u[2]*sz)/2. # rotation
@@ -62,7 +64,15 @@ def global_spin_rotation(m,vector = np.array([0.,0.,1.]),angle = 0.0,
   # same rotation at every site, so this is just a repeated block-diagonal;
   # np.kron avoids scipy.sparse.bmat, which mishandles the n=1 (single
   # site per cell) case (raises "blocks must be 2-D")
-  R = np.kron(np.eye(n),rot) # full rotation matrix
+  return np.kron(np.eye(n),rot) # full rotation matrix
+
+
+def global_spin_rotation(m,vector = np.array([0.,0.,1.]),angle = 0.0,
+                             spiral = False,atoms = None):
+  """ Rotates a matrix along a certain qvector """
+  n = m.shape[0]//2 # number of sites
+  if atoms is not None: raise # per-atom rotation not implemented
+  R = build_rotation_matrix(n,vector=vector,angle=angle)
   if spiral:  # for spin spiral
     mout = R @ m  # rotate matrix
   else:  # normal global rotation

--- a/src/pyqula/selfconsistency/densitydensity.py
+++ b/src/pyqula/selfconsistency/densitydensity.py
@@ -467,10 +467,22 @@ def densitydensity(h,filling=0.5,mu=None,verbose=0,use_jax=False,**kwargs):
     # Now compute the total energy
     h = scf.hamiltonian
     etot = h.get_total_energy(nk=h.nk)
-    if mu is None: 
+    if mu is None:
         etot += h.fermi*h.intra.shape[0]*filling # add the Fermi energy
     #print("Occupied energies",etot)
-    etot += get_dc_energy(scf.v,scf.dm) # add the double counting energy
+    # get_dc_energy assumes dm's shape matches v's, which is never
+    # Nambu-doubled even when h (hence scf.dm) is BdG -- so the electron
+    # sector must be extracted from scf.dm first for a BdG h, or this
+    # silently reads the wrong entries (mixing electron and hole rows/cols
+    # of the reordered Nambu matrix), giving a total energy that is not
+    # even consistent between a primitive cell and a supercell of the same
+    # system (caught via that exact check)
+    dm_dc = scf.dm
+    if h.has_eh:
+        from .. import superconductivity
+        dm_dc = {key: superconductivity.get_eh_sector(m,i=0,j=0)
+                for (key,m) in scf.dm.items()}
+    etot += get_dc_energy(scf.v,dm_dc) # add the double counting energy
     etot = etot.real
     scf.total_energy = etot
     if verbose>1:

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -228,17 +228,107 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
     Only integration="ed" and the plain-mixing solver are supported (unlike
     Vinteraction/SzSz/SxSx/SySy, which forward to the full
     generic_densitydensity solver zoo)."""
+    if not h0.has_spin: raise ValueError("Jinteraction needs a spinful Hamiltonian")
+    if h0.has_eh: raise ValueError("Jinteraction is not implemented for BdG Hamiltonians")
+    h1 = h0.get_multicell().get_dense()
+    vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
+    vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
+    vy = _build_v(h1, Jy1, Jy2, Jy3, Jyr)
+    return _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
+            maxerror, maxite, T, verbose, constrains)
+
+
+def _build_density_v(h, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None):
+    """Build the spin-orbital density-density interaction matrix -- uniform
+    across all four spin blocks (V1/V2/V3 neighbor shells, optional general
+    Vr(r) function), plus an onsite U between up/down -- exactly mirroring
+    Vinteraction's own construction (selfconsistency/densitydensity.py).
+    Kept as a small separate copy here (rather than refactoring Vinteraction
+    to share it) to avoid touching that already-tested, widely-used code
+    path; see _build_v's docstring for why the neighbor-shell key set this
+    produces is independent of which of V1/V2/V3 happen to be zero."""
+    from .. import specialhopping
+    from .densitydensity import obj2geometryarray
+    nd = h.geometry.neighbor_distances()
+    mgenerator = specialhopping.distance_hopping_matrix(
+            [V1/2., V2/2., V3/2.], nd[0:3])
+    hv = h.geometry.get_hamiltonian(has_spin=False, is_multicell=True,
+            mgenerator=mgenerator)
+    if Vr is not None:
+        hv1 = h.geometry.get_hamiltonian(has_spin=False, is_multicell=True,
+                tij=Vr)
+        hv = hv + hv1
+    v = hv.get_hopping_dict()
+    U = obj2geometryarray(U, h.geometry)
+    for d in v:
+        m = v[d]
+        n = m.shape[0]
+        m1 = np.zeros((2*n, 2*n), dtype=np.complex128)
+        for i in range(n):
+            for j in range(n):
+                m1[2*i, 2*j] = m[i, j]
+                m1[2*i+1, 2*j] = m[i, j]
+                m1[2*i, 2*j+1] = m[i, j]
+                m1[2*i+1, 2*j+1] = m[i, j]
+        v[d] = m1
+    for i in range(n):
+        v[(0, 0, 0)][2*i, 2*i+1] += U[i]/2.
+        v[(0, 0, 0)][2*i+1, 2*i] += U[i]/2.
+    return v
+
+
+def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
+        Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
+        Jz1=0.0, Jz2=0.0, Jz3=0.0, Jxr=None, Jyr=None, Jzr=None,
+        mf=None, filling=0.5, mu=None, mix=0.1, nk=8, maxerror=1e-5, maxite=None,
+        T=1e-7, verbose=0, constrains=[]):
+    """Self-consistent mean field combining density-density interactions
+    (U onsite Hubbard, V1/V2/V3/Vr neighbor-shell -- same convention as
+    Vinteraction) with anisotropic spin-spin exchange (Jx/Jy/Jz Sa_i Sa_j
+    -- same convention as Jinteraction) in a single SCF loop.
+
+    This works by combining the two existing SCF modes rather than
+    inventing new decoupling math: density-density interactions and
+    Sz_i Sz_j are both already density-density interactions in the
+    spin-orbital basis (Vinteraction's uniform sign pattern across the
+    four spin blocks vs. SzSz's +/-1/4 one -- see the module docstring and
+    _build_v), and Hartree-Fock decoupling (get_mf_normal) is linear in the
+    interaction matrix, so the density-density contribution can simply be
+    added into Jinteraction's z-channel matrix before entering its shared
+    SCF loop -- no separate channel, and no rotation, needed for it (unlike
+    Jx/Jy, which do need the rotate-decouple-rotate-back trick). The x/y
+    channels are handled exactly as in Jinteraction.
+
+    See Vinteraction and Jinteraction for the individual parameter
+    conventions; only integration="ed" and the plain-mixing solver are
+    supported (unlike Vinteraction/SzSz/SxSx/SySy)."""
+    if not h0.has_spin: raise ValueError("VJinteraction needs a spinful Hamiltonian")
+    if h0.has_eh: raise ValueError("VJinteraction is not implemented for BdG Hamiltonians")
+    h1 = h0.get_multicell().get_dense()
+    vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
+    vd = _build_density_v(h1, V1, V2, V3, U, Vr)
+    vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
+    vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
+    vy = _build_v(h1, Jy1, Jy2, Jy3, Jyr)
+    return _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
+            maxerror, maxite, T, verbose, constrains)
+
+
+def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
+        maxerror, maxite, T, verbose, constrains):
+    """Shared SCF core for Jinteraction/VJinteraction: decouples the
+    z-channel matrix `vz` directly (Hartree-Fock density-density in the
+    lab/computational spin basis) and the x/y-channel matrices `vx`/`vy`
+    by rotating the density matrix into the frame where that axis is the
+    computational z axis, applying the same decoupling there, and rotating
+    the resulting mean field back before summing all three contributions
+    -- see Jinteraction's docstring for the physics. `h1` must already be
+    h0.get_multicell().get_dense()."""
     from .densitydensity import (get_dm, get_mf_normal, mix_mf, diff_mf,
             update_hamiltonian, set_hoppings, hamiltonian2dict,
             get_dc_energy, SCF)
     from .mfconstrains import obj2mf
-    if not h0.has_spin: raise ValueError("Jinteraction needs a spinful Hamiltonian")
-    if h0.has_eh: raise ValueError("Jinteraction is not implemented for BdG Hamiltonians")
-    h1 = h0.get_multicell().get_dense()
     h1.nk = nk
-    vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
-    vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
-    vy = _build_v(h1, Jy1, Jy2, Jy3, Jyr)
     # union of the three channels' bond directions: in general the
     # neighbor-shell hopping-dict builder could prune a channel's key set
     # differently depending on which of its J's are zero, so the lab-frame

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -278,7 +278,7 @@ def _build_density_v(h, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None):
 
 
 def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
-        J1=0.0, J2=0.0, J3=0.0, Jr=None, Jx=0.0, Jy=0.0, Jz=0.0,
+        J1=0.0, J2=0.0, J3=0.0, Jr=None, J1x=0.0, J1y=0.0, J1z=0.0,
         mf=None, filling=0.5, mu=None, mix=0.1, nk=8, maxerror=1e-5, maxite=None,
         T=1e-7, verbose=0, constrains=[]):
     """Self-consistent mean field combining density-density interactions
@@ -288,10 +288,10 @@ def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
     J1/J2/J3 (+ Jr, a general distance-dependent function) are isotropic
     Heisenberg-like exchange, J*(Sx_i Sx_j + Sy_i Sy_j + Sz_i Sz_j), for the
     first/second/third neighbor shells -- the same first/second/third
-    neighbor-shell convention as V1/V2/V3. Jx/Jy/Jz are an additional,
+    neighbor-shell convention as V1/V2/V3. J1x/J1y/J1z are an additional,
     optional anisotropic correction, added on top of J1 for the
     first-neighbor shell only (e.g. the effective first-neighbor Jz
-    coupling is J1+Jz); second/third neighbors stay purely isotropic. All
+    coupling is J1+J1z); second/third neighbors stay purely isotropic. All
     default to 0, i.e. plain density-density with no spin-spin exchange.
 
     This works by combining the two existing SCF modes rather than
@@ -312,11 +312,11 @@ def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
     if not h0.has_spin: raise ValueError("VJinteraction needs a spinful Hamiltonian")
     if h0.has_eh: raise ValueError("VJinteraction is not implemented for BdG Hamiltonians")
     h1 = h0.get_multicell().get_dense()
-    vz = _build_v(h1, J1+Jz, J2, J3, Jr)
+    vz = _build_v(h1, J1+J1z, J2, J3, Jr)
     vd = _build_density_v(h1, V1, V2, V3, U, Vr)
     vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
-    vx = _build_v(h1, J1+Jx, J2, J3, Jr)
-    vy = _build_v(h1, J1+Jy, J2, J3, Jr)
+    vx = _build_v(h1, J1+J1x, J2, J3, Jr)
+    vy = _build_v(h1, J1+J1y, J2, J3, Jr)
     return _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             maxerror, maxite, T, verbose, constrains)
 

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -244,7 +244,7 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
     _run_anisotropic_scf's docstring for why (in short: extending the x/y
     rotate-decouple-rotate-back trick to also generate anomalous/pairing
     mean field from Jx/Jy is a separate, unverified extension)."""
-    if not h0.has_spin: raise ValueError("Jinteraction needs a spinful Hamiltonian")
+    if not h0.has_spin: return NotImplemented # only for spinful systems, same as SzSz/SxSx/SySy
     h1 = h0.get_multicell().get_dense()
     vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
     vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
@@ -332,7 +332,7 @@ def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
     density-density and exchange conventions respectively; only
     integration="ed" and the plain-mixing solver are supported (unlike
     Vinteraction/SzSz/SxSx/SySy)."""
-    if not h0.has_spin: raise ValueError("VJinteraction needs a spinful Hamiltonian")
+    if not h0.has_spin: return NotImplemented # only for spinful systems, same as SzSz/SxSx/SySy
     h1 = h0.get_multicell().get_dense()
     vz = _build_v(h1, J1+J1z, J2, J3, Jr)
     vd = _build_density_v(h1, V1, V2, V3, U, Vr)
@@ -496,10 +496,19 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         if callback_mf is not None: mfnew = callback_mf(mfnew)
         scf = SCF()
         scf.hamiltonian = h
+        # z-channel matrix only (for a normal-state VJinteraction this
+        # already includes the folded-in density-density vd, but never the
+        # x/y channels, and never vd separately for a Nambu VJinteraction --
+        # unlike Vinteraction/SzSz/SxSx/SySy, there is no single matrix
+        # that fully captures this multi-channel interaction, so callers
+        # relying on h.V for e.g. get_magnon_bands/get_rpa_kernel_poles
+        # (which expect a single, onsite-only interaction matrix) should
+        # not assume this represents the whole exchange+density-density mix
+        scf.hamiltonian.V = vz
         scf.hamiltonian0 = h0_dense
         scf.mf = mfnew
         scf.dm = dm_lab
-        scf.v = vz # for identify_symmetry_breaking's tolerance bookkeeping
+        scf.v = vz # see scf.hamiltonian.V above for what this does/doesn't capture
         scf.tol = maxerror
         return scf
 

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -1,0 +1,291 @@
+# Mean-field (Hartree-Fock) treatment of spin-spin (S_i.S_j) interactions
+# in spinful Hamiltonians.
+#
+# Sz_i Sz_j = 1/4 (n_iu - n_id)(n_ju - n_jd)
+#           = 1/4 (n_iu n_ju - n_iu n_jd - n_id n_ju + n_id n_jd)
+#
+# is already a density-density interaction (sum of V_ab n_a n_b over
+# spin-orbitals a,b) of exactly the form that selfconsistency.densitydensity's
+# generic Hartree-Fock engine decouples -- it does not know or care what the
+# spin-orbital index physically represents. So SzSz needs no new decoupling
+# math, only a v matrix with the right +/-1/4 sign pattern in the 2x2 spin
+# blocks (see _build_v below), fed into the existing densitydensity() engine.
+#
+# SxSx and SySy are obtained by a global spin rotation that maps the physical
+# x (or y) axis onto the computational z axis, running the SzSz machinery
+# there, and rotating the converged Hamiltonian back. Concretely, writing
+# c' = U c for a site-independent spin rotation U, a Hamiltonian h written in
+# terms of c becomes h_tilde = U h U^dagger written in terms of c'; the
+# density matrix transforms the same way. Requiring U^dagger sz U = sx (so
+# that "Sz" measured with the primed operators is "Sx" of the original ones)
+# is satisfied by the existing rotate_spin.global_spin_rotation machinery
+# (exposed as Hamiltonian.global_spin_rotation) for:
+#   x-axis: vector=[0,1,0], angle=+0.5   (undo with angle=-0.5)
+#   y-axis: vector=[1,0,0], angle=-0.5   (undo with angle=+0.5)
+# verified numerically against the Pauli matrices.
+
+import numpy as np
+
+from .. import specialhopping
+from ..multihopping import MultiHopping
+from ..rotate_spin import global_spin_rotation as _gsr
+
+# NOTE: densitydensity is imported lazily (inside each function, not here at
+# module level). densitydensity.py itself does `from ..meanfield import
+# identify_symmetry_breaking` at its very bottom, and meanfield.py imports
+# this module (spinspin) to re-export SzSz/SxSx/SySy/Jinteraction -- an
+# eager top-level import here would close that cycle and fail (with an
+# AttributeError on a partially-initialized module) depending on which
+# module a caller happens to import first.
+
+
+def _build_v(h, J1=0.0, J2=0.0, J3=0.0, Jr=None):
+    """Build the spin-orbital interaction matrix for a J1/J2/J3 (plus
+    optional general Jr(r) function) neighbor-shell SzSz coupling,
+    following exactly the same neighbor-shell/hopping-dict construction as
+    Vinteraction, but with the +/-1/4 sign pattern of
+    Sz_i Sz_j = 1/4 (n_iu-n_id)(n_ju-n_jd) in the four spin blocks instead
+    of Vinteraction's uniform value. Same key set (bond directions) as
+    Vinteraction's v for the same geometry, since that is fixed purely by
+    the geometry's neighbor shells, independent of which J's are zero."""
+    nd = h.geometry.neighbor_distances() # distances to the neighbor shells
+    mgenerator = specialhopping.distance_hopping_matrix(
+            [J1/2., J2/2., J3/2.], nd[0:3])
+    hv = h.geometry.get_hamiltonian(has_spin=False, is_multicell=True,
+            mgenerator=mgenerator)
+    if Jr is not None:
+        hv1 = h.geometry.get_hamiltonian(has_spin=False, is_multicell=True,
+                tij=Jr)
+        hv = hv + hv1
+    v = hv.get_hopping_dict()
+    for d in v:
+        m = v[d]
+        n = m.shape[0]
+        m1 = np.zeros((2*n, 2*n), dtype=np.complex128)
+        for i in range(n):
+            for j in range(n):
+                m1[2*i, 2*j] = m[i, j]/4.       # up-up
+                m1[2*i, 2*j+1] = -m[i, j]/4.    # up-down
+                m1[2*i+1, 2*j] = -m[i, j]/4.    # down-up
+                m1[2*i+1, 2*j+1] = m[i, j]/4.   # down-down
+        v[d] = m1
+    return v
+
+
+def _callback_mf_constrains(h, constrains):
+    if not constrains: return None
+    from . import mfconstrains
+    def callback_mf(mf):
+        return mfconstrains.enforce_constrains(mf, h, constrains)
+    return callback_mf
+
+
+def SzSz(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
+    """Self-consistent Hartree-Fock mean field for a
+    H = sum J1/J2/J3 (+ Jr(r)) Sz_i Sz_j
+    spin-spin interaction (first/second/third neighbor shells, plus an
+    optional general distance function Jr). J>0 is antiferromagnetic
+    (Heisenberg-like sign convention), J<0 favors a ferromagnetic
+    instability along z."""
+    from .densitydensity import densitydensity
+    if not h.has_spin: return NotImplemented # only for spinful systems
+    if h.has_eh: return NotImplemented # not implemented for BdG Hamiltonians
+    h = h.get_multicell().get_dense()
+    v = _build_v(h, J1, J2, J3, Jr)
+    callback_mf = _callback_mf_constrains(h, constrains)
+    return densitydensity(h, v=v, callback_mf=callback_mf, **kwargs)
+
+
+_AXIS_ROTATION = {
+        "x": dict(vector=[0., 1., 0.], angle=0.5),
+        "y": dict(vector=[1., 0., 0.], angle=-0.5),
+        }
+
+
+def _rotate_mf_guess(h0, axis, mf, **fwd):
+    """Turn a user-supplied `mf=` guess -- given in the lab frame, as a
+    string mode name (e.g. "ferroX"), a matrix, a dict, or a Hamiltonian --
+    into a plain hopping dict expressed in the internally-rotated frame
+    that SzSz(hr,...) actually gets called with. Without this, an
+    axis-appropriate guess like mf="ferroX" passed to SxSx would be handed
+    unrotated to the internal (rotated) SzSz call, seeding a guess that has
+    no overlap with the computational-z order parameter the rotated SCF
+    loop actually looks for -- silently killing the intended instability."""
+    if mf is None: return None
+    from .mfconstrains import obj2mf
+    if isinstance(mf, str):
+        from ..meanfield import guess
+        mf = guess(h0, mode=mf) # resolve the guess in the lab frame first
+        if mf is None: return None # e.g. guess() modes that return nothing
+    mf = obj2mf(mf) # normalize matrix/Hamiltonian/dict to a hopping dict
+    return {d: _gsr(m, **fwd) for (d, m) in mf.items()}
+
+
+def _rotated_axis_exchange(h, axis, J1, J2, J3, Jr, constrains, **kwargs):
+    fwd = _AXIS_ROTATION[axis]
+    bwd = dict(fwd); bwd["angle"] = -fwd["angle"]
+    h0 = h.get_multicell().get_dense() # keep the original, unrotated reference
+    hr = h0.copy()
+    hr.global_spin_rotation(**fwd) # rotate so that `axis` becomes computational z
+    mf0 = kwargs.pop("mf", None)
+    mf_rot = _rotate_mf_guess(h0, axis, mf0, **fwd)
+    scf = SzSz(hr, J1, J2, J3, Jr, constrains=constrains, mf=mf_rot, **kwargs)
+    if scf.hamiltonian is not None:
+        scf.hamiltonian.global_spin_rotation(**bwd) # rotate the result back
+    # scf.mf/scf.dm/scf.v are left expressed in the internally-rotated frame;
+    # scf.hamiltonian (the user-facing result) and scf.hamiltonian0 are in
+    # the original frame
+    scf.hamiltonian0 = h0
+    return scf
+
+
+def SxSx(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
+    """Self-consistent Hartree-Fock mean field for a
+    H = sum J1/J2/J3 (+ Jr(r)) Sx_i Sx_j
+    spin-spin interaction. Implemented by rotating the problem so that x
+    becomes the computational z axis, running SzSz there, and rotating the
+    converged Hamiltonian back -- see the module docstring."""
+    if not h.has_spin: return NotImplemented
+    if h.has_eh: return NotImplemented
+    return _rotated_axis_exchange(h, "x", J1, J2, J3, Jr, constrains, **kwargs)
+
+
+def SySy(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
+    """Self-consistent Hartree-Fock mean field for a
+    H = sum J1/J2/J3 (+ Jr(r)) Sy_i Sy_j
+    spin-spin interaction. Implemented by rotating the problem so that y
+    becomes the computational z axis, running SzSz there, and rotating the
+    converged Hamiltonian back -- see the module docstring."""
+    if not h.has_spin: return NotImplemented
+    if h.has_eh: return NotImplemented
+    return _rotated_axis_exchange(h, "y", J1, J2, J3, Jr, constrains, **kwargs)
+
+
+def _rotate_dict(dd, vector, angle):
+    return {k: _gsr(m, vector=vector, angle=angle) for (k, m) in dd.items()}
+
+
+def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
+        Jz1=0.0, Jz2=0.0, Jz3=0.0, Jxr=None, Jyr=None, Jzr=None,
+        mf=None, filling=0.5, mu=None, mix=0.1, nk=8, maxerror=1e-5, maxite=None,
+        T=1e-7, verbose=0, constrains=[], **kwargs):
+    """Self-consistent anisotropic exchange mean field,
+    H = sum Jx Sx_i Sx_j + Jy Sy_i Sy_j + Jz Sz_i Sz_j,
+    combining all three channels in a single SCF loop: at every iteration
+    the z channel is decoupled directly (Hartree-Fock density-density in
+    the lab/computational spin basis) and the x/y channels are decoupled
+    by rotating the density matrix into the frame where that axis is the
+    computational z axis, applying the same decoupling there, and rotating
+    the resulting mean field back before summing the three contributions
+    -- see SxSx/SySy for the single-axis version of the same trick.
+
+    Unlike SxSx/SySy, `mf` (a string mode name, matrix, dict or Hamiltonian
+    guess) is used directly in the lab frame with no rotation: the mf
+    iterate driving this SCF loop always lives in the lab frame -- only the
+    per-iteration x/y mean-field *contributions* are computed by a
+    temporary excursion into a rotated frame, rotated back before being
+    summed in.
+
+    Only integration="ed" and the plain-mixing solver are supported (unlike
+    Vinteraction/SzSz/SxSx/SySy, which forward to the full
+    generic_densitydensity solver zoo)."""
+    from .densitydensity import (get_dm, get_mf_normal, mix_mf, diff_mf,
+            update_hamiltonian, set_hoppings, hamiltonian2dict,
+            get_dc_energy, SCF)
+    from .mfconstrains import obj2mf
+    if not h0.has_spin: raise ValueError("Jinteraction needs a spinful Hamiltonian")
+    if h0.has_eh: raise ValueError("Jinteraction is not implemented for BdG Hamiltonians")
+    h1 = h0.get_multicell().get_dense()
+    h1.nk = nk
+    vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
+    vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
+    vy = _build_v(h1, Jy1, Jy2, Jy3, Jyr)
+    # union of the three channels' bond directions: in general the
+    # neighbor-shell hopping-dict builder could prune a channel's key set
+    # differently depending on which of its J's are zero, so the lab-frame
+    # density matrix must be requested at the union, not just vz's keys
+    v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy))}
+    rx, rxb = _AXIS_ROTATION["x"], dict(_AXIS_ROTATION["x"], angle=-_AXIS_ROTATION["x"]["angle"])
+    ry, ryb = _AXIS_ROTATION["y"], dict(_AXIS_ROTATION["y"], angle=-_AXIS_ROTATION["y"]["angle"])
+    callback_mf = _callback_mf_constrains(h1, constrains)
+
+    def callback_h(hh):
+        if mu is None:
+            fermi = hh.get_fermi4filling(filling, nk=hh.nk)
+            hh.fermi = fermi
+            hh.shift_fermi(-fermi)
+        else:
+            hh.shift_fermi(-mu)
+        return hh
+
+    hop0 = hamiltonian2dict(h1)
+    h0_dense = h1.copy() # reference Hamiltonian before the mean field is added
+
+    def compute_mf(dm_lab):
+        mf = get_mf_normal(vz, dm_lab)
+        dm_x = _rotate_dict(dm_lab, **rx)
+        mf_x = _rotate_dict(get_mf_normal(vx, dm_x), **rxb)
+        mf = (MultiHopping(mf) + MultiHopping(mf_x)).get_dict()
+        dm_y = _rotate_dict(dm_lab, **ry)
+        mf_y = _rotate_dict(get_mf_normal(vy, dm_y), **ryb)
+        mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
+        return mf
+
+    def f(mf):
+        h = h1.copy()
+        hop = update_hamiltonian(hop0, mf)
+        set_hoppings(h, hop)
+        h = callback_h(h)
+        dm_lab = get_dm(h, v_dirs, nk=nk, T=T, integration="ed")
+        mfnew = compute_mf(dm_lab)
+        if callback_mf is not None: mfnew = callback_mf(mfnew)
+        scf = SCF()
+        scf.hamiltonian = h
+        scf.hamiltonian0 = h0_dense
+        scf.mf = mfnew
+        scf.dm = dm_lab
+        scf.v = vz # for identify_symmetry_breaking's tolerance bookkeeping
+        scf.tol = maxerror
+        return scf
+
+    if mf is None:
+        mf = dict()
+        for d in vz: mf[d] = np.exp(1j*np.random.random(h1.intra.shape))*1e-1
+        mf[(0, 0, 0)] = mf[(0, 0, 0)] + mf[(0, 0, 0)].T.conjugate()
+    else:
+        if isinstance(mf, str):
+            from ..meanfield import guess
+            mf = guess(h0_dense, mode=mf)
+        mf = obj2mf(mf)
+
+    ite = 0
+    while True:
+        scf = f(mf)
+        mfnew = scf.mf
+        diff = diff_mf(mfnew, mf)
+        mf = mix_mf(mfnew, mf, mix=mix)
+        if callback_mf is not None: mf = callback_mf(mf)
+        if verbose > 0: print("ERROR in the SCF cycle", ite, diff)
+        if diff < maxerror:
+            scf = f(mfnew) # last iteration, with the unmixed mean field
+            scf.converged = True
+            break
+        if maxite is not None and ite >= maxite:
+            scf.converged = False
+            print("No convergence has been reached in", maxite, "iterations, stopping")
+            break
+        ite += 1
+
+    # total energy: sum of occupied energies plus the double-counting
+    # correction for each of the three (independently-rotated) channels
+    h = scf.hamiltonian
+    etot = h.get_total_energy(nk=h.nk)
+    if mu is None:
+        etot += h.fermi*h.intra.shape[0]*filling
+    etot += get_dc_energy(vz, scf.dm)
+    dm_x = _rotate_dict(scf.dm, **rx)
+    etot += get_dc_energy(vx, dm_x)
+    dm_y = _rotate_dict(scf.dm, **ry)
+    etot += get_dc_energy(vy, dm_y)
+    scf.total_energy = etot.real
+    return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -548,10 +548,16 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
 
     # total energy: sum of occupied energies plus the double-counting
     # correction for each of the three (independently-rotated) exchange
-    # channels (electron sector only, matching compute_mf) plus vd's (if
-    # any), which -- like its mean field -- uses the full, un-extracted
-    # density matrix, matching how Vinteraction/densitydensity.py already
-    # computes it
+    # channels, plus vd's (if any) -- all electron-sector only. get_dc_energy
+    # assumes dm's shape matches v's (2n, never Nambu-doubled), so it must
+    # always be fed the extracted electron sector for a BdG h1, never the
+    # full Nambu-sized scf.dm directly (verified: passing the full dm here,
+    # matching how Vinteraction/densitydensity.py's own total-energy
+    # computation does it for its single v, makes the reported total_energy
+    # inconsistent between a primitive cell and a supercell of the same
+    # system for a Nambu Hamiltonian -- a real, pre-existing bug in that
+    # shared code, out of scope to fix here, but not one to reproduce for
+    # vd just because it happens to match precedent)
     h = scf.hamiltonian
     etot = h.get_total_energy(nk=h.nk)
     if mu is None:
@@ -563,6 +569,6 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     dm_y = _rot_dm(dme, Ry)
     etot += get_dc_energy(vy, dm_y)
     if vd is not None:
-        etot += get_dc_energy(vd, scf.dm)
+        etot += get_dc_energy(vd, dme)
     scf.total_energy = etot.real
     return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -162,7 +162,36 @@ def SySy(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
 
 
 def _rotate_dict(dd, vector, angle):
+    """Rotate a dict of Hamiltonian-like (hopping/mean-field) matrices by a
+    global spin rotation -- these live in the same convention as
+    Hamiltonian.intra, for which R @ m @ R^dagger is the correct
+    transformation (as used by Hamiltonian.global_spin_rotation, validated
+    by SxSx/SySy)."""
     return {k: _gsr(m, vector=vector, angle=angle) for (k, m) in dd.items()}
+
+
+def _rotate_dm(dd, vector, angle):
+    """Rotate a dict of *density matrices* by a global spin rotation.
+
+    get_density_matrix's off-diagonal (spin-flip) entries are stored in a
+    transposed convention relative to a Hamiltonian matrix -- normal_term_ij
+    (selfconsistency/densitydensity.py) deliberately reads dm[j,i] rather
+    than dm[i,j] to reconstruct a physically-meaningful mean field from it.
+    For a Hermitian matrix, transposing is the same as complex-conjugating,
+    so a density matrix in this convention is the complex conjugate of the
+    "Hamiltonian-convention" matrix at the same site/bond. Naively rotating
+    it with the same R @ m @ R^dagger used for Hamiltonians (_rotate_dict)
+    therefore silently flips the sign of the imaginary (y) Pauli component
+    while leaving the real (x, z) ones untouched -- caught by checking that
+    a random-direction initial guess converges to a moment collinear with
+    it (only Jinteraction is affected: SzSz/SxSx/SySy rotate the whole
+    Hamiltonian and run a native SCF in the rotated frame, never touching a
+    raw density matrix directly, so they never hit this). Conjugating
+    before and after the standard rotation corrects for it: if
+    dm_stored = conj(dm_physical), then
+    dm_stored' = conj(dm_physical') = conj(R @ conj(dm_stored) @ R^dagger)."""
+    return {k: np.conj(_gsr(np.conj(m), vector=vector, angle=angle))
+            for (k, m) in dd.items()}
 
 
 def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
@@ -223,10 +252,10 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
 
     def compute_mf(dm_lab):
         mf = get_mf_normal(vz, dm_lab)
-        dm_x = _rotate_dict(dm_lab, **rx)
-        mf_x = _rotate_dict(get_mf_normal(vx, dm_x), **rxb)
+        dm_x = _rotate_dm(dm_lab, **rx) # dm needs the conjugated rotation
+        mf_x = _rotate_dict(get_mf_normal(vx, dm_x), **rxb) # mf does not
         mf = (MultiHopping(mf) + MultiHopping(mf_x)).get_dict()
-        dm_y = _rotate_dict(dm_lab, **ry)
+        dm_y = _rotate_dm(dm_lab, **ry)
         mf_y = _rotate_dict(get_mf_normal(vy, dm_y), **ryb)
         mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
         return mf
@@ -283,9 +312,9 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
     if mu is None:
         etot += h.fermi*h.intra.shape[0]*filling
     etot += get_dc_energy(vz, scf.dm)
-    dm_x = _rotate_dict(scf.dm, **rx)
+    dm_x = _rotate_dm(scf.dm, **rx) # dm needs the conjugated rotation, see compute_mf
     etot += get_dc_energy(vx, dm_x)
-    dm_y = _rotate_dict(scf.dm, **ry)
+    dm_y = _rotate_dm(scf.dm, **ry)
     etot += get_dc_energy(vy, dm_y)
     scf.total_energy = etot.real
     return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -80,7 +80,21 @@ def _callback_mf_constrains(h, constrains):
     return callback_mf
 
 
-def SzSz(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
+def _compose_callbacks(a, b):
+    """Return a function applying `a` then `b`, skipping whichever of the
+    two is None. Used to let an externally-supplied callback_mf (e.g. the
+    lab-frame constrains wrapper built by _rotated_axis_exchange) compose
+    with the one SzSz derives from its own `constrains` argument, instead
+    of one silently overriding the other."""
+    if a is None: return b
+    if b is None: return a
+    def combined(mf):
+        return b(a(mf))
+    return combined
+
+
+def SzSz(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], callback_mf=None,
+        **kwargs):
     """Self-consistent Hartree-Fock mean field for a
     H = sum J1/J2/J3 (+ Jr(r)) Sz_i Sz_j
     spin-spin interaction (first/second/third neighbor shells, plus an
@@ -92,7 +106,8 @@ def SzSz(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
     if h.has_eh: return NotImplemented # not implemented for BdG Hamiltonians
     h = h.get_multicell().get_dense()
     v = _build_v(h, J1, J2, J3, Jr)
-    callback_mf = _callback_mf_constrains(h, constrains)
+    constrain_cb = _callback_mf_constrains(h, constrains)
+    callback_mf = _compose_callbacks(constrain_cb, callback_mf)
     return densitydensity(h, v=v, callback_mf=callback_mf, **kwargs)
 
 
@@ -121,6 +136,24 @@ def _rotate_mf_guess(h0, axis, mf, **fwd):
     return {d: _gsr(m, **fwd) for (d, m) in mf.items()}
 
 
+def _rotated_constrains_callback(h0, constrains, fwd, bwd):
+    """Build a callback_mf that enforces `constrains` in the LAB frame (as
+    the user expects -- e.g. "no_offplane_magnetism" meaning the real z
+    axis) even though the mean field iterate SzSz(hr,...) actually mixes
+    lives in the internally-rotated frame where `axis` is the computational
+    z axis. Passing `constrains` straight through to the inner SzSz call
+    would enforce it against the ROTATED frame's z axis instead -- e.g.
+    "no_offplane_magnetism" under SxSx would silently constrain the
+    physical x component (computational z in that frame), not z."""
+    if not constrains: return None
+    from . import mfconstrains
+    def callback_mf(mf_rot):
+        mf_lab = _rotate_dict(mf_rot, **bwd) # mf lives in Hamiltonian convention
+        mf_lab = mfconstrains.enforce_constrains(mf_lab, h0, constrains)
+        return _rotate_dict(mf_lab, **fwd) # back into the rotated SCF's frame
+    return callback_mf
+
+
 def _rotated_axis_exchange(h, axis, J1, J2, J3, Jr, constrains, **kwargs):
     fwd = _AXIS_ROTATION[axis]
     bwd = dict(fwd); bwd["angle"] = -fwd["angle"]
@@ -129,7 +162,8 @@ def _rotated_axis_exchange(h, axis, J1, J2, J3, Jr, constrains, **kwargs):
     hr.global_spin_rotation(**fwd) # rotate so that `axis` becomes computational z
     mf0 = kwargs.pop("mf", None)
     mf_rot = _rotate_mf_guess(h0, axis, mf0, **fwd)
-    scf = SzSz(hr, J1, J2, J3, Jr, constrains=constrains, mf=mf_rot, **kwargs)
+    callback_mf = _rotated_constrains_callback(h0, constrains, fwd, bwd)
+    scf = SzSz(hr, J1, J2, J3, Jr, mf=mf_rot, callback_mf=callback_mf, **kwargs)
     if scf.hamiltonian is not None:
         scf.hamiltonian.global_spin_rotation(**bwd) # rotate the result back
     # scf.mf/scf.dm/scf.v are left expressed in the internally-rotated frame;
@@ -170,34 +204,10 @@ def _rotate_dict(dd, vector, angle):
     return {k: _gsr(m, vector=vector, angle=angle) for (k, m) in dd.items()}
 
 
-def _rotate_dm(dd, vector, angle):
-    """Rotate a dict of *density matrices* by a global spin rotation.
-
-    get_density_matrix's off-diagonal (spin-flip) entries are stored in a
-    transposed convention relative to a Hamiltonian matrix -- normal_term_ij
-    (selfconsistency/densitydensity.py) deliberately reads dm[j,i] rather
-    than dm[i,j] to reconstruct a physically-meaningful mean field from it.
-    For a Hermitian matrix, transposing is the same as complex-conjugating,
-    so a density matrix in this convention is the complex conjugate of the
-    "Hamiltonian-convention" matrix at the same site/bond. Naively rotating
-    it with the same R @ m @ R^dagger used for Hamiltonians (_rotate_dict)
-    therefore silently flips the sign of the imaginary (y) Pauli component
-    while leaving the real (x, z) ones untouched -- caught by checking that
-    a random-direction initial guess converges to a moment collinear with
-    it (only Jinteraction is affected: SzSz/SxSx/SySy rotate the whole
-    Hamiltonian and run a native SCF in the rotated frame, never touching a
-    raw density matrix directly, so they never hit this). Conjugating
-    before and after the standard rotation corrects for it: if
-    dm_stored = conj(dm_physical), then
-    dm_stored' = conj(dm_physical') = conj(R @ conj(dm_stored) @ R^dagger)."""
-    return {k: np.conj(_gsr(np.conj(m), vector=vector, angle=angle))
-            for (k, m) in dd.items()}
-
-
 def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
         Jz1=0.0, Jz2=0.0, Jz3=0.0, Jxr=None, Jyr=None, Jzr=None,
         mf=None, filling=0.5, mu=None, mix=0.1, nk=8, maxerror=1e-5, maxite=None,
-        T=1e-7, verbose=0, constrains=[], **kwargs):
+        T=1e-7, verbose=0, constrains=[]):
     """Self-consistent anisotropic exchange mean field,
     H = sum Jx Sx_i Sx_j + Jy Sy_i Sy_j + Jz Sz_i Sz_j,
     combining all three channels in a single SCF loop: at every iteration
@@ -234,8 +244,50 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
     # differently depending on which of its J's are zero, so the lab-frame
     # density matrix must be requested at the union, not just vz's keys
     v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy))}
-    rx, rxb = _AXIS_ROTATION["x"], dict(_AXIS_ROTATION["x"], angle=-_AXIS_ROTATION["x"]["angle"])
-    ry, ryb = _AXIS_ROTATION["y"], dict(_AXIS_ROTATION["y"], angle=-_AXIS_ROTATION["y"]["angle"])
+    # the x/y rotations are fixed for the whole SCF loop, so build the
+    # (small, 2x2-block) rotation matrices once via build_rotation_matrix
+    # instead of paying a fresh matrix exponential on every one of the many
+    # _rotate_dict/_rotate_dm calls compute_mf makes each iteration; the
+    # backward rotation is just the forward matrix's dagger (R(-angle) =
+    # R(angle)^dagger), so only Rx/Ry need to be built
+    from ..rotate_spin import build_rotation_matrix
+    n_orb = h1.intra.shape[0]//2
+    Rx = build_rotation_matrix(n_orb, **_AXIS_ROTATION["x"])
+    Ry = build_rotation_matrix(n_orb, **_AXIS_ROTATION["y"])
+
+    def _rot_dict(dd, R):
+        """Rotate a dict of Hamiltonian-like (hopping/mean-field) matrices:
+        these live in the same convention as Hamiltonian.intra, for which
+        R @ m @ R^dagger is the correct transformation (as used by
+        Hamiltonian.global_spin_rotation, validated by SxSx/SySy)."""
+        Rd = R.conj().T
+        return {k: R @ m @ Rd for (k, m) in dd.items()}
+
+    def _rot_dm(dd, R):
+        """Rotate a dict of *density matrices*, which need a different
+        (conjugate-sandwiched) transformation than _rot_dict.
+
+        get_density_matrix's off-diagonal (spin-flip) entries are stored in
+        a transposed convention relative to a Hamiltonian matrix --
+        normal_term_ij (selfconsistency/densitydensity.py) deliberately
+        reads dm[j,i] rather than dm[i,j] to reconstruct a
+        physically-meaningful mean field from it. For a Hermitian matrix,
+        transposing is the same as complex-conjugating, so a density matrix
+        in this convention is the complex conjugate of the
+        "Hamiltonian-convention" matrix at the same site/bond. Naively
+        rotating it with R @ m @ R^dagger (_rot_dict) therefore silently
+        flips the sign of the imaginary (y) Pauli component while leaving
+        the real (x, z) ones untouched -- caught by checking that a
+        random-direction initial guess converges to a moment collinear with
+        it (only Jinteraction is affected: SzSz/SxSx/SySy rotate the whole
+        Hamiltonian and run a native SCF in the rotated frame, never
+        touching a raw density matrix directly, so they never hit this).
+        Conjugating before and after the standard rotation corrects for it:
+        if dm_stored = conj(dm_physical), then
+        dm_stored' = conj(dm_physical') = conj(R @ conj(dm_stored) @ R^dagger)."""
+        Rd = R.conj().T
+        return {k: np.conj(R @ np.conj(m) @ Rd) for (k, m) in dd.items()}
+
     callback_mf = _callback_mf_constrains(h1, constrains)
 
     def callback_h(hh):
@@ -252,11 +304,11 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
 
     def compute_mf(dm_lab):
         mf = get_mf_normal(vz, dm_lab)
-        dm_x = _rotate_dm(dm_lab, **rx) # dm needs the conjugated rotation
-        mf_x = _rotate_dict(get_mf_normal(vx, dm_x), **rxb) # mf does not
+        dm_x = _rot_dm(dm_lab, Rx) # dm needs the conjugated rotation
+        mf_x = _rot_dict(get_mf_normal(vx, dm_x), Rx.conj().T) # mf does not
         mf = (MultiHopping(mf) + MultiHopping(mf_x)).get_dict()
-        dm_y = _rotate_dm(dm_lab, **ry)
-        mf_y = _rotate_dict(get_mf_normal(vy, dm_y), **ryb)
+        dm_y = _rot_dm(dm_lab, Ry)
+        mf_y = _rot_dict(get_mf_normal(vy, dm_y), Ry.conj().T)
         mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
         return mf
 
@@ -279,7 +331,13 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
 
     if mf is None:
         mf = dict()
-        for d in vz: mf[d] = np.exp(1j*np.random.random(h1.intra.shape))*1e-1
+        # seed over v_dirs (the vz/vx/vy key union), not just vz's own keys:
+        # a channel with only its own neighbor shells (e.g. Jx1 nonzero,
+        # Jz1=Jz2=Jz3=0) can have bond-direction keys absent from vz, and
+        # diff_mf below only iterates the keys already present in this
+        # initial guess, so seeding too few of them would make those
+        # channels invisible to the very first convergence check
+        for d in v_dirs: mf[d] = np.exp(1j*np.random.random(h1.intra.shape))*1e-1
         mf[(0, 0, 0)] = mf[(0, 0, 0)] + mf[(0, 0, 0)].T.conjugate()
     else:
         if isinstance(mf, str):
@@ -312,9 +370,9 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
     if mu is None:
         etot += h.fermi*h.intra.shape[0]*filling
     etot += get_dc_energy(vz, scf.dm)
-    dm_x = _rotate_dm(scf.dm, **rx) # dm needs the conjugated rotation, see compute_mf
+    dm_x = _rot_dm(scf.dm, Rx) # dm needs the conjugated rotation, see compute_mf
     etot += get_dc_energy(vx, dm_x)
-    dm_y = _rotate_dm(scf.dm, **ry)
+    dm_y = _rot_dm(scf.dm, Ry)
     etot += get_dc_energy(vy, dm_y)
     scf.total_energy = etot.real
     return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -100,10 +100,18 @@ def SzSz(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], callback_mf=None,
     spin-spin interaction (first/second/third neighbor shells, plus an
     optional general distance function Jr). J>0 is antiferromagnetic
     (Heisenberg-like sign convention), J<0 favors a ferromagnetic
-    instability along z."""
+    instability along z.
+
+    Works for BdG (Nambu, h.has_eh=True) Hamiltonians too: densitydensity()
+    already dispatches has_eh-aware Hartree-Fock+anomalous decoupling
+    (selfconsistency.densitydensity.get_mf) generically for any v matrix,
+    including SzSz's +/-1/4 one, with no changes needed here -- verified
+    that a bare SzSz run (no pre-existing pairing) on a Nambu Hamiltonian
+    converges to a purely magnetic state (zero anomalous/pairing mean
+    field) that exactly matches the non-Nambu SzSz result in the electron
+    sector."""
     from .densitydensity import densitydensity
     if not h.has_spin: return NotImplemented # only for spinful systems
-    if h.has_eh: return NotImplemented # not implemented for BdG Hamiltonians
     h = h.get_multicell().get_dense()
     v = _build_v(h, J1, J2, J3, Jr)
     constrain_cb = _callback_mf_constrains(h, constrains)
@@ -178,9 +186,10 @@ def SxSx(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
     H = sum J1/J2/J3 (+ Jr(r)) Sx_i Sx_j
     spin-spin interaction. Implemented by rotating the problem so that x
     becomes the computational z axis, running SzSz there, and rotating the
-    converged Hamiltonian back -- see the module docstring."""
+    converged Hamiltonian back -- see the module docstring. Works for BdG
+    (Nambu, h.has_eh=True) Hamiltonians too: global_spin_rotation already
+    handles the Nambu case correctly (see its docstring)."""
     if not h.has_spin: return NotImplemented
-    if h.has_eh: return NotImplemented
     return _rotated_axis_exchange(h, "x", J1, J2, J3, Jr, constrains, **kwargs)
 
 
@@ -189,9 +198,10 @@ def SySy(h, J1=0.0, J2=0.0, J3=0.0, Jr=None, constrains=[], **kwargs):
     H = sum J1/J2/J3 (+ Jr(r)) Sy_i Sy_j
     spin-spin interaction. Implemented by rotating the problem so that y
     becomes the computational z axis, running SzSz there, and rotating the
-    converged Hamiltonian back -- see the module docstring."""
+    converged Hamiltonian back -- see the module docstring. Works for BdG
+    (Nambu, h.has_eh=True) Hamiltonians too: global_spin_rotation already
+    handles the Nambu case correctly (see its docstring)."""
     if not h.has_spin: return NotImplemented
-    if h.has_eh: return NotImplemented
     return _rotated_axis_exchange(h, "y", J1, J2, J3, Jr, constrains, **kwargs)
 
 
@@ -227,9 +237,14 @@ def Jinteraction(h0, Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
 
     Only integration="ed" and the plain-mixing solver are supported (unlike
     Vinteraction/SzSz/SxSx/SySy, which forward to the full
-    generic_densitydensity solver zoo)."""
+    generic_densitydensity solver zoo).
+
+    Works for BdG (Nambu, h0.has_eh=True) Hamiltonians too, but decouples
+    the exchange interaction in the normal (electron) sector only -- see
+    _run_anisotropic_scf's docstring for why (in short: extending the x/y
+    rotate-decouple-rotate-back trick to also generate anomalous/pairing
+    mean field from Jx/Jy is a separate, unverified extension)."""
     if not h0.has_spin: raise ValueError("Jinteraction needs a spinful Hamiltonian")
-    if h0.has_eh: raise ValueError("Jinteraction is not implemented for BdG Hamiltonians")
     h1 = h0.get_multicell().get_dense()
     vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
     vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
@@ -300,29 +315,38 @@ def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
     spin-orbital basis (Vinteraction's uniform sign pattern across the
     four spin blocks vs. SzSz's +/-1/4 one -- see the module docstring and
     _build_v), and Hartree-Fock decoupling (get_mf_normal) is linear in the
-    interaction matrix, so the density-density contribution can simply be
-    added into Jinteraction's z-channel matrix before entering its shared
-    SCF loop -- no separate channel, and no rotation, needed for it (unlike
-    the x/y channels, which do need the rotate-decouple-rotate-back trick).
+    interaction matrix, so for a normal-state (non-BdG) Hamiltonian the
+    density-density contribution is simply added into the z-channel matrix
+    before entering the shared SCF loop -- no separate channel, and no
+    rotation, needed for it (unlike the x/y channels, which do need the
+    rotate-decouple-rotate-back trick).
+
+    For a BdG (Nambu, h0.has_eh=True) Hamiltonian, density-density and
+    exchange are instead kept as two separate contributions summed each
+    SCF iteration (see _run_anisotropic_scf's docstring): density-density
+    keeps its existing full normal+anomalous treatment (identical to
+    Vinteraction), while the exchange channels are decoupled in the normal
+    (electron) sector only, i.e. J does not itself induce pairing here.
 
     See Vinteraction and Jinteraction for further background on the
     density-density and exchange conventions respectively; only
     integration="ed" and the plain-mixing solver are supported (unlike
     Vinteraction/SzSz/SxSx/SySy)."""
     if not h0.has_spin: raise ValueError("VJinteraction needs a spinful Hamiltonian")
-    if h0.has_eh: raise ValueError("VJinteraction is not implemented for BdG Hamiltonians")
     h1 = h0.get_multicell().get_dense()
     vz = _build_v(h1, J1+J1z, J2, J3, Jr)
     vd = _build_density_v(h1, V1, V2, V3, U, Vr)
-    vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
     vx = _build_v(h1, J1+J1x, J2, J3, Jr)
     vy = _build_v(h1, J1+J1y, J2, J3, Jr)
+    if not h1.has_eh: # normal-state: fold density-density directly into vz
+        vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
+        vd = None
     return _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
-            maxerror, maxite, T, verbose, constrains)
+            maxerror, maxite, T, verbose, constrains, vd=vd)
 
 
 def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
-        maxerror, maxite, T, verbose, constrains):
+        maxerror, maxite, T, verbose, constrains, vd=None):
     """Shared SCF core for Jinteraction/VJinteraction: decouples the
     z-channel matrix `vz` directly (Hartree-Fock density-density in the
     lab/computational spin basis) and the x/y-channel matrices `vx`/`vy`
@@ -330,25 +354,57 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     computational z axis, applying the same decoupling there, and rotating
     the resulting mean field back before summing all three contributions
     -- see Jinteraction's docstring for the physics. `h1` must already be
-    h0.get_multicell().get_dense()."""
-    from .densitydensity import (get_dm, get_mf_normal, mix_mf, diff_mf,
-            update_hamiltonian, set_hoppings, hamiltonian2dict,
+    h0.get_multicell().get_dense().
+
+    `vd`, if given, is an additional density-density interaction matrix
+    (Vinteraction's convention) added to the mean field each iteration.
+    For a normal-state h1, the caller should have already folded this into
+    `vz` directly instead (Hartree-Fock decoupling is linear in the
+    interaction, so this is equivalent and does not need a separate
+    channel) and passed vd=None. `vd` as a genuinely separate argument only
+    matters for a BdG (Nambu, h1.has_eh=True) h1: there, vx/vy/vz (the
+    exchange channels) are decoupled in the normal (electron) sector only
+    -- extracting it from the full Nambu density matrix, decoupling with
+    get_mf_normal exactly as for a normal-state Hamiltonian (verified: the
+    x/y-rotation trick's _rot_dm/_rot_dict logic, and
+    rotate_spin.global_spin_rotation more generally, both already handle
+    Nambu-doubled matrices correctly with no changes, since pyqula's Nambu
+    convention (sctk/reorder.py) groups each site's electron pair and hole
+    pair as separate, identically-transforming (up,down)-like 2-blocks),
+    then embedded back into a full Nambu matrix with zero anomalous part --
+    while `vd` gets the full has_eh-aware treatment (get_mf, both normal
+    and anomalous/pairing), identical to how Vinteraction already handles
+    it. In short: J does not itself induce superconducting pairing here,
+    only V/U can (matching the existing Zeeman+attractive-V1 triplet-SC
+    machinery) -- extending the x/y rotation trick to also rotate the
+    anomalous sector is a separate, unverified piece of physics left for a
+    future extension."""
+    from .densitydensity import (get_dm, get_mf_normal, get_mf, mix_mf,
+            diff_mf, update_hamiltonian, set_hoppings, hamiltonian2dict,
             get_dc_energy, SCF)
     from .mfconstrains import obj2mf
+    has_eh = h1.has_eh
+    if has_eh: from .. import superconductivity
     h1.nk = nk
-    # union of the three channels' bond directions: in general the
-    # neighbor-shell hopping-dict builder could prune a channel's key set
-    # differently depending on which of its J's are zero, so the lab-frame
-    # density matrix must be requested at the union, not just vz's keys
-    v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy))}
+    # union of the three exchange channels' bond directions (+ vd's, if
+    # given): in general the neighbor-shell hopping-dict builder could
+    # prune a channel's key set differently depending on which of its J's
+    # (or V's) are zero, so the lab-frame density matrix must be requested
+    # at the union, not just vz's keys
+    v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy) |
+            (set(vd) if vd is not None else set()))}
     # the x/y rotations are fixed for the whole SCF loop, so build the
     # (small, 2x2-block) rotation matrices once via build_rotation_matrix
     # instead of paying a fresh matrix exponential on every one of the many
     # _rotate_dict/_rotate_dm calls compute_mf makes each iteration; the
     # backward rotation is just the forward matrix's dagger (R(-angle) =
-    # R(angle)^dagger), so only Rx/Ry need to be built
+    # R(angle)^dagger), so only Rx/Ry need to be built. Sized from vz's own
+    # shape (always the plain spin-orbital size, never Nambu-doubled, even
+    # when h1 itself is BdG) rather than h1.intra.shape, since the exchange
+    # channels are always decoupled in the (electron-sector-sized) normal
+    # channel -- see this function's docstring.
     from ..rotate_spin import build_rotation_matrix
-    n_orb = h1.intra.shape[0]//2
+    n_orb = vz[(0, 0, 0)].shape[0]//2
     Rx = build_rotation_matrix(n_orb, **_AXIS_ROTATION["x"])
     Ry = build_rotation_matrix(n_orb, **_AXIS_ROTATION["y"])
 
@@ -399,14 +455,35 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     hop0 = hamiltonian2dict(h1)
     h0_dense = h1.copy() # reference Hamiltonian before the mean field is added
 
+    def electron_sector(dd):
+        """Extract the normal (electron-electron) sector from a dict of
+        (possibly Nambu-sized) density matrices; a no-op for normal-state
+        h1."""
+        if not has_eh: return dd
+        return {k: superconductivity.get_eh_sector(m, i=0, j=0)
+                for (k, m) in dd.items()}
+
+    def embed_normal(mfe):
+        """Embed an electron-sector-only mean field dict back into full
+        Nambu form, with zero anomalous (pairing) part; a no-op for
+        normal-state h1."""
+        if not has_eh: return mfe
+        return {k: superconductivity.build_nambu_matrix(m)
+                for (k, m) in mfe.items()}
+
     def compute_mf(dm_lab):
-        mf = get_mf_normal(vz, dm_lab)
-        dm_x = _rot_dm(dm_lab, Rx) # dm needs the conjugated rotation
+        dme_lab = electron_sector(dm_lab) # exchange channels: normal sector only
+        mf = get_mf_normal(vz, dme_lab)
+        dm_x = _rot_dm(dme_lab, Rx) # dm needs the conjugated rotation
         mf_x = _rot_dict(get_mf_normal(vx, dm_x), Rx.conj().T) # mf does not
         mf = (MultiHopping(mf) + MultiHopping(mf_x)).get_dict()
-        dm_y = _rot_dm(dm_lab, Ry)
+        dm_y = _rot_dm(dme_lab, Ry)
         mf_y = _rot_dict(get_mf_normal(vy, dm_y), Ry.conj().T)
         mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
+        mf = embed_normal(mf)
+        if vd is not None: # density-density: full normal+anomalous treatment
+            mf_d = get_mf(vd, dm_lab, has_eh=has_eh)
+            mf = (MultiHopping(mf) + MultiHopping(mf_d)).get_dict()
         return mf
 
     def f(mf):
@@ -461,15 +538,22 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         ite += 1
 
     # total energy: sum of occupied energies plus the double-counting
-    # correction for each of the three (independently-rotated) channels
+    # correction for each of the three (independently-rotated) exchange
+    # channels (electron sector only, matching compute_mf) plus vd's (if
+    # any), which -- like its mean field -- uses the full, un-extracted
+    # density matrix, matching how Vinteraction/densitydensity.py already
+    # computes it
     h = scf.hamiltonian
     etot = h.get_total_energy(nk=h.nk)
     if mu is None:
         etot += h.fermi*h.intra.shape[0]*filling
-    etot += get_dc_energy(vz, scf.dm)
-    dm_x = _rot_dm(scf.dm, Rx) # dm needs the conjugated rotation, see compute_mf
+    dme = electron_sector(scf.dm)
+    etot += get_dc_energy(vz, dme)
+    dm_x = _rot_dm(dme, Rx) # dm needs the conjugated rotation, see compute_mf
     etot += get_dc_energy(vx, dm_x)
-    dm_y = _rot_dm(scf.dm, Ry)
+    dm_y = _rot_dm(dme, Ry)
     etot += get_dc_energy(vy, dm_y)
+    if vd is not None:
+        etot += get_dc_energy(vd, scf.dm)
     scf.total_energy = etot.real
     return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -278,38 +278,45 @@ def _build_density_v(h, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None):
 
 
 def VJinteraction(h0, V1=0.0, V2=0.0, V3=0.0, U=0.0, Vr=None,
-        Jx1=0.0, Jx2=0.0, Jx3=0.0, Jy1=0.0, Jy2=0.0, Jy3=0.0,
-        Jz1=0.0, Jz2=0.0, Jz3=0.0, Jxr=None, Jyr=None, Jzr=None,
+        J1=0.0, J2=0.0, J3=0.0, Jr=None, Jx=0.0, Jy=0.0, Jz=0.0,
         mf=None, filling=0.5, mu=None, mix=0.1, nk=8, maxerror=1e-5, maxite=None,
         T=1e-7, verbose=0, constrains=[]):
     """Self-consistent mean field combining density-density interactions
     (U onsite Hubbard, V1/V2/V3/Vr neighbor-shell -- same convention as
-    Vinteraction) with anisotropic spin-spin exchange (Jx/Jy/Jz Sa_i Sa_j
-    -- same convention as Jinteraction) in a single SCF loop.
+    Vinteraction) with spin-spin exchange in a single SCF loop.
+
+    J1/J2/J3 (+ Jr, a general distance-dependent function) are isotropic
+    Heisenberg-like exchange, J*(Sx_i Sx_j + Sy_i Sy_j + Sz_i Sz_j), for the
+    first/second/third neighbor shells -- the same first/second/third
+    neighbor-shell convention as V1/V2/V3. Jx/Jy/Jz are an additional,
+    optional anisotropic correction, added on top of J1 for the
+    first-neighbor shell only (e.g. the effective first-neighbor Jz
+    coupling is J1+Jz); second/third neighbors stay purely isotropic. All
+    default to 0, i.e. plain density-density with no spin-spin exchange.
 
     This works by combining the two existing SCF modes rather than
     inventing new decoupling math: density-density interactions and
-    Sz_i Sz_j are both already density-density interactions in the
+    Sa_i Sa_j are both already density-density interactions in the
     spin-orbital basis (Vinteraction's uniform sign pattern across the
     four spin blocks vs. SzSz's +/-1/4 one -- see the module docstring and
     _build_v), and Hartree-Fock decoupling (get_mf_normal) is linear in the
     interaction matrix, so the density-density contribution can simply be
     added into Jinteraction's z-channel matrix before entering its shared
     SCF loop -- no separate channel, and no rotation, needed for it (unlike
-    Jx/Jy, which do need the rotate-decouple-rotate-back trick). The x/y
-    channels are handled exactly as in Jinteraction.
+    the x/y channels, which do need the rotate-decouple-rotate-back trick).
 
-    See Vinteraction and Jinteraction for the individual parameter
-    conventions; only integration="ed" and the plain-mixing solver are
-    supported (unlike Vinteraction/SzSz/SxSx/SySy)."""
+    See Vinteraction and Jinteraction for further background on the
+    density-density and exchange conventions respectively; only
+    integration="ed" and the plain-mixing solver are supported (unlike
+    Vinteraction/SzSz/SxSx/SySy)."""
     if not h0.has_spin: raise ValueError("VJinteraction needs a spinful Hamiltonian")
     if h0.has_eh: raise ValueError("VJinteraction is not implemented for BdG Hamiltonians")
     h1 = h0.get_multicell().get_dense()
-    vz = _build_v(h1, Jz1, Jz2, Jz3, Jzr)
+    vz = _build_v(h1, J1+Jz, J2, J3, Jr)
     vd = _build_density_v(h1, V1, V2, V3, U, Vr)
     vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
-    vx = _build_v(h1, Jx1, Jx2, Jx3, Jxr)
-    vy = _build_v(h1, Jy1, Jy2, Jy3, Jyr)
+    vx = _build_v(h1, J1+Jx, J2, J3, Jr)
+    vy = _build_v(h1, J1+Jy, J2, J3, Jr)
     return _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             maxerror, maxite, T, verbose, constrains)
 

--- a/tests/scf/test_rotational_symmetry_sc.py
+++ b/tests/scf/test_rotational_symmetry_sc.py
@@ -34,6 +34,43 @@ def test_superconducting_gap_is_rotationally_invariant():
         f"SCF gap is not rotationally invariant: {diff}"
 
 
+def test_superconducting_energy_per_atom_matches_in_a_supercell():
+    """The self-consistent total energy per atom, and the gap, must be the
+    same whether computed in the minimal (primitive) cell or a supercell
+    of it -- same physical lattice, just a bigger repeated unit. The two
+    k-meshes are scaled consistently (nk_supercell = nk_primitive/N) so
+    both sample the same physical k-points folded into the smaller BZ.
+
+    Regression test for a real bug in the total-energy computation shared
+    by every density-density mean field (get_mean_field_hamiltonian /
+    Vinteraction, and, through its own density-density channel,
+    VJinteraction): get_dc_energy(v, dm) assumes dm's shape matches v's
+    (2n, never Nambu-doubled), but the total energy used to be computed
+    with the full, un-extracted Nambu-sized density matrix for a BdG
+    Hamiltonian -- giving a total energy per atom that changed with the
+    supercell size (caught via this exact check)."""
+    g = geometry.bichain()
+    nk0 = 40
+
+    def run(gg, nk):
+        h = gg.get_hamiltonian()
+        h.add_exchange([0.3, 0., 0.])
+        h.turn_nambu()
+        return h.get_mean_field_hamiltonian(V1=-2., filling=.3, mf="random",
+                nk=nk, maxerror=SCF_MAXERROR, return_total_energy=True)
+
+    h1, etot1 = run(g, nk0)
+    natoms1 = len(g.r)
+    g2 = g.get_supercell(2)
+    h2, etot2 = run(g2, nk0//2)
+    natoms2 = len(g2.r)
+    assert natoms2 == 2*natoms1
+
+    assert np.isclose(h1.get_gap(), h2.get_gap(), atol=1e-3)
+    assert np.isclose(etot1/natoms1, etot2/natoms2, atol=1e-3), \
+        (etot1/natoms1, etot2/natoms2)
+
+
 def test_triplet_dvector_is_perpendicular_to_zeeman_direction():
     """A Zeeman field along an arbitrary direction v induces equal-spin
     triplet pairing quantized along v (Delta_ud, the Sz=0 pairing channel

--- a/tests/scf/test_rotational_symmetry_sc.py
+++ b/tests/scf/test_rotational_symmetry_sc.py
@@ -1,19 +1,25 @@
 import numpy as np
 
 from pyqula import geometry
+from pyqula import hamiltonians  # noqa: F401 -- resolve sctk.dvector's import order
+from pyqula.sctk.dvector import matrix2dvector
 from testutils import SCF_MAXERROR
+
+
+def _mean_field_for_random_direction(h0, v):
+    h1 = h0.copy()
+    h1.add_exchange(v)
+    h1.turn_nambu()
+    return h1.get_mean_field_hamiltonian(nk=20, mf="random", V1=-2.,
+                                          filling=.3,
+                                          maxerror=SCF_MAXERROR,
+                                          return_total_energy=True)
 
 
 def _gap_for_random_direction(h0):
     v = np.random.random(3) - .5  # random Zeeman direction
     v = 4 * v / np.sqrt(v.dot(v))  # normalize
-    h1 = h0.copy()
-    h1.add_exchange(v)
-    h1.turn_nambu()
-    h, etot = h1.get_mean_field_hamiltonian(nk=20, mf="random", V1=-2.,
-                                             filling=.3,
-                                             maxerror=SCF_MAXERROR,
-                                             return_total_energy=True)
+    h, etot = _mean_field_for_random_direction(h0, v)
     return h.get_gap()
 
 
@@ -26,3 +32,31 @@ def test_superconducting_gap_is_rotationally_invariant():
     diff = gaps - np.mean(gaps)
     assert np.max(np.abs(diff)) < SCF_MAXERROR * 10, \
         f"SCF gap is not rotationally invariant: {diff}"
+
+
+def test_triplet_dvector_is_perpendicular_to_zeeman_direction():
+    """A Zeeman field along an arbitrary direction v induces equal-spin
+    triplet pairing quantized along v (Delta_ud, the Sz=0 pairing channel
+    measured along v, is suppressed). In the d-vector representation
+    Delta = i(d.sigma)sigma_y, this channel IS the component of d along v
+    (dvector.delta2dvector sets dz = Delta_ud), so the physically correct
+    signature of rotational symmetry here is that d is exactly
+    PERPENDICULAR to v for any v -- not parallel to it. Checked as
+    |v.d|/|d| ~ 0 at several k-points, for several random v."""
+    g = geometry.bichain()
+    h0 = g.get_hamiltonian()
+    for _ in range(4):
+        v = np.random.random(3) - .5
+        v = 4 * v / np.sqrt(v.dot(v))
+        h, etot = _mean_field_for_random_direction(h0, v)
+        hk = h.get_hk_gen()
+        for kx in np.linspace(0.05, 0.45, 5):
+            m = hk([kx, 0., 0.])
+            d = matrix2dvector(m) # (3, nsites, nsites) complex d-vector matrices
+            dsum = np.array([d[0].sum(), d[1].sum(), d[2].sum()])
+            dnorm = np.linalg.norm(dsum)
+            if dnorm < 1e-8: continue # negligible triplet weight at this k
+            ratio = abs(np.dot(v, dsum))/dnorm
+            assert ratio < 1e-3, \
+                f"d-vector not perpendicular to Zeeman direction {v} " \
+                f"at k={kx}: |v.d|/|d| = {ratio}"

--- a/tests/scf/test_spinspin_ferro_chain.py
+++ b/tests/scf/test_spinspin_ferro_chain.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+
+
+def _mz(J1, filling=0.2, nk=10, maxerror=1e-6, maxite=300):
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    scf = meanfield.SzSz(h, J1=J1, mf="ferroZ", nk=nk, maxerror=maxerror,
+            mix=0.3, maxite=maxite, filling=filling)
+    assert scf.converged, "SCF did not converge"
+    m = scf.hamiltonian.get_magnetization()
+    return np.mean(np.abs(m[:, 2]))
+
+
+def test_szsz_ferromagnetic_moment_grows_with_coupling_strength():
+    """H = J1 Sz_i Sz_j on a chain (J1<0, the ferromagnetic sign convention
+    -- same convention as the Heisenberg model, where J>0 is
+    antiferromagnetic): the self-consistent uniform z moment must grow with
+    |J1|. (J1>0, the antiferromagnetic sign, is not exercised here: Neel
+    order cannot be represented on this chain's 1-atom unit cell, so the
+    SCF loop correctly fails to converge to a translationally-invariant
+    fixed point for it -- that is expected chain physics, not a bug.)"""
+    mz_weak = _mz(-0.1)
+    mz_strong = _mz(-2.0)
+    assert mz_strong > 5*mz_weak, \
+        f"expected the moment to grow with |J1|: {mz_weak} vs {mz_strong}"
+    assert mz_strong > 0.05, "no sizable ferromagnetic moment at strong coupling"

--- a/tests/scf/test_spinspin_nambu.py
+++ b/tests/scf/test_spinspin_nambu.py
@@ -112,7 +112,18 @@ def test_jinteraction_isotropic_on_nambu_preserves_su2_symmetry():
 def test_vjinteraction_v_only_on_nambu_matches_vinteraction():
     """VJinteraction with only V1 (no exchange) on a BdG Hamiltonian must
     reduce exactly to Vinteraction's existing, already-validated Nambu
-    (spin-triplet superconductivity) treatment."""
+    (spin-triplet superconductivity) treatment, including total_energy.
+
+    This also regression-tests a real bug in densitydensity.py's total
+    energy computation (shared by Vinteraction and, through vd,
+    VJinteraction), found and fixed while checking that VJinteraction
+    gives the same result in a supercell as in a minimal cell:
+    get_dc_energy(v, dm) assumes dm's shape matches v's (2n, never
+    Nambu-doubled), but the total-energy code used to pass it the full,
+    un-extracted Nambu-sized density matrix for a BdG Hamiltonian, silently
+    reading the wrong entries -- giving a total energy that was not even
+    consistent between a primitive cell and a supercell of the same
+    system (see test_vjinteraction_nambu_supercell_consistency)."""
     g = geometry.bichain()
     h0 = g.get_hamiltonian()
 
@@ -129,10 +140,10 @@ def test_vjinteraction_v_only_on_nambu_matches_vinteraction():
             nk=20, maxerror=MAXERROR)
 
     assert scf_v.converged and scf_vj.converged
-    assert np.isclose(scf_v.total_energy, scf_vj.total_energy, atol=1e-3), \
-        (scf_v.total_energy, scf_vj.total_energy)
     assert np.isclose(scf_v.hamiltonian.get_gap(), scf_vj.hamiltonian.get_gap(),
             atol=1e-3)
+    assert np.isclose(scf_v.total_energy, scf_vj.total_energy, atol=1e-3), \
+        (scf_v.total_energy, scf_vj.total_energy)
 
 
 def test_vjinteraction_isotropic_J_and_V_on_nambu_preserves_su2_symmetry():

--- a/tests/scf/test_spinspin_nambu.py
+++ b/tests/scf/test_spinspin_nambu.py
@@ -1,0 +1,157 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+from pyqula.superconductivity import get_eh_sector
+
+MAXERROR = 1e-6
+
+
+def _pauli(m):
+    mx = (m[0, 1] + m[1, 0]).real/2
+    my = (m[1, 0] - m[0, 1]).imag/2
+    mz = (m[0, 0] - m[1, 1]).real/2
+    return np.array([mx, my, mz])
+
+
+def test_szsz_on_nambu_matches_normal_state_electron_sector():
+    """SzSz on a BdG (Nambu) Hamiltonian must converge to a purely magnetic
+    state -- densitydensity()'s existing has_eh dispatch already handles
+    the electron+anomalous Wick decoupling generically for any v matrix,
+    with no changes needed in SzSz itself -- whose electron sector exactly
+    matches the non-Nambu SzSz result, with zero anomalous (pairing) mean
+    field spontaneously generated (SzSz alone has no attractive channel to
+    seed pairing)."""
+    g = geometry.chain()
+
+    h_normal = g.get_hamiltonian(has_spin=True)
+    scf_normal = meanfield.SzSz(h_normal, J1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, filling=0.2)
+    assert scf_normal.converged
+    m_normal = scf_normal.hamiltonian.get_magnetization()
+
+    h_nambu = g.get_hamiltonian(has_spin=True)
+    h_nambu.setup_nambu_spinor()
+    scf_nambu = meanfield.SzSz(h_nambu, J1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, filling=0.2)
+    assert scf_nambu.converged
+    mf_full = np.array(scf_nambu.hamiltonian.intra) - np.array(scf_nambu.hamiltonian0.intra)
+    ee = get_eh_sector(mf_full, i=0, j=0)
+    eh = get_eh_sector(mf_full, i=0, j=1)
+
+    assert np.max(np.abs(eh)) < 1e-8, "SzSz should not spontaneously pair"
+    # the electron sector's own z-magnetization must match the non-Nambu run
+    mz_nambu = (ee[0, 0] - ee[1, 1]).real/2
+    mz_normal = np.mean(m_normal[:, 2])
+    assert np.isclose(mz_nambu, mz_normal, atol=1e-3), (mz_nambu, mz_normal)
+
+
+def test_sxsx_sysy_szsz_on_nambu_are_rotations_of_each_other():
+    """SzSz/SxSx/SySy on a BdG Hamiltonian must remain rotationally
+    consistent: same total energy, and the electron-sector mean field
+    ordering along the intended axis, with zero spurious pairing --
+    verifying that rotate_spin.global_spin_rotation (used, unmodified, by
+    SxSx/SySy's rotate-solve-rotate-back trick) is correct for Nambu
+    Hamiltonians too."""
+    g = geometry.chain()
+    results = {}
+    for axis, fn, guess in [("z", meanfield.SzSz, "ferroZ"),
+                             ("x", meanfield.SxSx, "ferroX"),
+                             ("y", meanfield.SySy, "ferroY")]:
+        h = g.get_hamiltonian(has_spin=True)
+        h.setup_nambu_spinor()
+        scf = fn(h, J1=-2.0, mf=guess, nk=10, maxerror=MAXERROR, mix=0.3,
+                filling=0.2)
+        assert scf.converged, f"axis {axis} did not converge"
+        mf_full = np.array(scf.hamiltonian.intra) - np.array(scf.hamiltonian0.intra)
+        ee = get_eh_sector(mf_full, i=0, j=0)
+        eh = get_eh_sector(mf_full, i=0, j=1)
+        assert np.max(np.abs(eh)) < 1e-8, f"axis {axis}: spurious pairing"
+        results[axis] = (scf.total_energy, _pauli(ee))
+
+    etots = np.array([results[a][0] for a in "xyz"])
+    assert np.max(np.abs(etots - np.mean(etots))) < 1e-4, etots
+
+    for axis, expected_component in [("x", 0), ("y", 1), ("z", 2)]:
+        m = results[axis][1]
+        assert abs(m[expected_component]) > 0.05, (axis, m)
+        others = [abs(m[i]) for i in range(3) if i != expected_component]
+        assert max(others) < 1e-3, (axis, m)
+
+
+def test_jinteraction_isotropic_on_nambu_preserves_su2_symmetry():
+    """Jinteraction (isotropic Jx=Jy=Jz) on a BdG Hamiltonian, seeded with a
+    random-direction guess, must converge to a moment collinear with it
+    (SU(2) symmetry preserved), with no spuriously induced pairing --
+    exercising Jinteraction's Nambu path, where the exchange channels are
+    decoupled in the electron sector only (see _run_anisotropic_scf's
+    docstring)."""
+    g = geometry.chain()
+    rng = np.random.default_rng(4)
+    for _ in range(3):
+        v = rng.random(3) - 0.5
+        v = v/np.linalg.norm(v)
+        h = g.get_hamiltonian(has_spin=True)
+        h.setup_nambu_spinor()
+        guess = h.copy()
+        guess.add_exchange(0.1*v)
+        scf = meanfield.Jinteraction(h, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0,
+                mf=guess, nk=10, maxerror=MAXERROR, mix=0.2, maxite=300,
+                filling=0.2)
+        assert scf.converged
+        mf_full = np.array(scf.hamiltonian.intra) - np.array(scf.hamiltonian0.intra)
+        ee = get_eh_sector(mf_full, i=0, j=0)
+        eh = get_eh_sector(mf_full, i=0, j=1)
+        assert np.max(np.abs(eh)) < 1e-8
+        m = _pauli(ee)
+        assert np.linalg.norm(m) > 0.05
+        cos_angle = np.dot(m/np.linalg.norm(m), v)
+        assert cos_angle > 1 - 1e-3, (v, m, cos_angle)
+
+
+def test_vjinteraction_v_only_on_nambu_matches_vinteraction():
+    """VJinteraction with only V1 (no exchange) on a BdG Hamiltonian must
+    reduce exactly to Vinteraction's existing, already-validated Nambu
+    (spin-triplet superconductivity) treatment."""
+    g = geometry.bichain()
+    h0 = g.get_hamiltonian()
+
+    h1 = h0.copy()
+    h1.add_exchange([0.3, 0., 0.])
+    h1.turn_nambu()
+    scf_v = meanfield.Vinteraction(h1, V1=-2.0, filling=0.3, mf="random",
+            nk=20, maxerror=MAXERROR)
+
+    h2 = h0.copy()
+    h2.add_exchange([0.3, 0., 0.])
+    h2.turn_nambu()
+    scf_vj = meanfield.VJinteraction(h2, V1=-2.0, filling=0.3, mf="random",
+            nk=20, maxerror=MAXERROR)
+
+    assert scf_v.converged and scf_vj.converged
+    assert np.isclose(scf_v.total_energy, scf_vj.total_energy, atol=1e-3), \
+        (scf_v.total_energy, scf_vj.total_energy)
+    assert np.isclose(scf_v.hamiltonian.get_gap(), scf_vj.hamiltonian.get_gap(),
+            atol=1e-3)
+
+
+def test_vjinteraction_isotropic_J_and_V_on_nambu_preserves_su2_symmetry():
+    """Combining an SU(2)-symmetric V1 pairing channel with an isotropic J1
+    exchange on a BdG Hamiltonian must keep the total energy independent of
+    the (arbitrary) exchange-field direction used to seed the SCF loop."""
+    g = geometry.bichain()
+    h0 = g.get_hamiltonian()
+    rng = np.random.default_rng(5)
+    etots = []
+    for _ in range(3):
+        v = rng.random(3) - 0.5
+        v = v/np.linalg.norm(v)
+        h = h0.copy()
+        h.add_exchange(0.3*v)
+        h.turn_nambu()
+        scf = meanfield.VJinteraction(h, V1=-1.0, J1=-0.3, filling=0.3,
+                mf="random", nk=20, maxerror=MAXERROR, mix=0.15, maxite=500)
+        assert scf.converged
+        etots.append(scf.total_energy)
+    etots = np.array(etots)
+    assert np.max(np.abs(etots - np.mean(etots))) < 1e-3, etots

--- a/tests/scf/test_spinspin_nambu.py
+++ b/tests/scf/test_spinspin_nambu.py
@@ -137,8 +137,9 @@ def test_vjinteraction_v_only_on_nambu_matches_vinteraction():
 
 def test_vjinteraction_isotropic_J_and_V_on_nambu_preserves_su2_symmetry():
     """Combining an SU(2)-symmetric V1 pairing channel with an isotropic J1
-    exchange on a BdG Hamiltonian must keep the total energy independent of
-    the (arbitrary) exchange-field direction used to seed the SCF loop."""
+    (ferromagnetic-sign, uniform order) exchange on a BdG Hamiltonian must
+    keep the total energy independent of the (arbitrary) exchange-field
+    direction used to seed the SCF loop."""
     g = geometry.bichain()
     h0 = g.get_hamiltonian()
     rng = np.random.default_rng(5)
@@ -155,3 +156,52 @@ def test_vjinteraction_isotropic_J_and_V_on_nambu_preserves_su2_symmetry():
         etots.append(scf.total_energy)
     etots = np.array(etots)
     assert np.max(np.abs(etots - np.mean(etots))) < 1e-3, etots
+
+
+def test_vjinteraction_afm_and_fm_J_with_attractive_V_preserve_su2_symmetry():
+    """Combining an attractive V1 (inducing superconductivity) with an
+    isotropic J1 exchange must keep the total energy independent of the
+    (arbitrary) direction of the fixed exchange field used to seed the
+    symmetry breaking, for BOTH signs of J1: J1<0 (ferromagnetic, uniform
+    order -- a uniform field) and J1>0 (antiferromagnetic, staggered/Neel
+    order -- a staggered [+v,-v] field, since Neel order needs at least a
+    2-site cell to represent). The SCF's own mean-field guess is an
+    unrelated random one in both cases (mf="random"), matching the
+    established convention for this kind of check (see
+    test_rotational_symmetry_sc.py's _gap_for_random_direction).
+
+    The antiferromagnetic+SC combination converges much more slowly than
+    the ferromagnetic one (monotonic but shallow, not oscillating -- a
+    genuine competition between the two orders, not a bug), hence the
+    larger mix/maxite for that branch."""
+    g = geometry.bichain()
+    h0 = g.get_hamiltonian()
+    rng = np.random.default_rng(6)
+
+    etots_fm = []
+    for _ in range(2):
+        v = rng.random(3) - 0.5
+        v = v/np.linalg.norm(v)
+        h = h0.copy()
+        h.add_exchange(0.3*v) # fixed uniform field -> ferromagnetic order
+        h.turn_nambu()
+        scf = meanfield.VJinteraction(h, V1=-2.0, J1=-1.0, filling=0.3,
+                mf="random", nk=20, maxerror=MAXERROR, mix=0.15, maxite=2000)
+        assert scf.converged
+        etots_fm.append(scf.total_energy)
+    etots_fm = np.array(etots_fm)
+    assert np.max(np.abs(etots_fm - np.mean(etots_fm))) < 1e-4, etots_fm
+
+    etots_afm = []
+    for _ in range(2):
+        v = rng.random(3) - 0.5
+        v = v/np.linalg.norm(v)
+        h = h0.copy()
+        h.add_exchange([v*0.3, -v*0.3]) # fixed staggered field -> Neel order
+        h.turn_nambu()
+        scf = meanfield.VJinteraction(h, V1=-2.0, J1=1.0, filling=0.3,
+                mf="random", nk=20, maxerror=MAXERROR, mix=0.3, maxite=3000)
+        assert scf.converged
+        etots_afm.append(scf.total_energy)
+    etots_afm = np.array(etots_afm)
+    assert np.max(np.abs(etots_afm - np.mean(etots_afm))) < 1e-4, etots_afm

--- a/tests/scf/test_spinspin_rotational_symmetry.py
+++ b/tests/scf/test_spinspin_rotational_symmetry.py
@@ -100,3 +100,76 @@ def test_jinteraction_random_direction_guess_gives_collinear_moment(seed):
     cos_angle = np.dot(m/np.linalg.norm(m), v)
     assert cos_angle > 1 - 1e-3, \
         f"moment {m} is not collinear with guess direction {v} (cos={cos_angle})"
+
+
+def test_sxsx_constrains_apply_in_the_lab_frame():
+    """`constrains` passed to SxSx/SySy must be enforced against the LAB
+    frame's axes, not the internally-rotated frame (where the requested
+    axis, not z, is the computational z axis). Regression test: passing
+    "no_offplane_magnetism" (removes lab-frame z) to an SxSx run must leave
+    the x-ordered moment untouched (z is ~0 there anyway), while
+    "no_inplane_magnetism" (removes lab-frame x,y) must suppress it
+    entirely, since this system has no mechanism to order along z. Before
+    the fix, constrains were enforced against the rotated frame's z axis
+    -- i.e. against the physical x axis for SxSx -- so
+    "no_offplane_magnetism" would have wiped out the x order instead of
+    leaving it alone."""
+    g = geometry.chain()
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf1 = meanfield.SxSx(h1, J1=-2.0, mf="ferroX", nk=10, maxerror=MAXERROR,
+            mix=0.3, maxite=300, filling=0.2,
+            constrains=["no_offplane_magnetism"])
+    assert scf1.converged
+    mx1 = np.mean(np.abs(scf1.hamiltonian.get_magnetization()[:, 0]))
+    assert mx1 > 0.05, \
+        "no_offplane_magnetism should not remove the (lab-frame) x order"
+
+    h2 = g.get_hamiltonian(has_spin=True)
+    scf2 = meanfield.SxSx(h2, J1=-2.0, mf="ferroX", nk=10, maxerror=MAXERROR,
+            mix=0.3, maxite=300, filling=0.2,
+            constrains=["no_inplane_magnetism"])
+    assert scf2.converged
+    m2 = np.mean(np.abs(scf2.hamiltonian.get_magnetization()), axis=0)
+    assert np.max(m2) < 1e-3, \
+        f"no_inplane_magnetism should remove all order here: {m2}"
+
+
+def test_jinteraction_single_axis_converges_from_default_guess():
+    """Regression test for a bug where Jinteraction's default (mf=None)
+    random guess was seeded only over vz's own bond-direction keys, not the
+    full vz/vx/vy union: for a coupling active only on an axis whose own
+    vz-equivalent has fewer keys (e.g. only Jx1 nonzero, so vz is reduced
+    to just the trivial onsite key), the very first convergence check could
+    be blind to the growing x-channel bond mean field, risking a spurious
+    early "converged". Checked against the known reference total energy for
+    this exact (Jx1-only, filling=0.2) setup."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    scf = meanfield.Jinteraction(h, Jx1=-2.0, nk=10, maxerror=MAXERROR,
+            mix=0.3, maxite=300, filling=0.2, mf=None)
+    assert scf.converged
+    assert np.isclose(scf.total_energy, -0.7043362879187306, atol=1e-4), \
+        scf.total_energy
+
+
+def test_jinteraction_rejects_unrecognized_kwargs():
+    """Jinteraction must not silently discard unrecognized keywords (it
+    used to accept and drop them via a dead **kwargs catch-all)."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    with pytest.raises(TypeError):
+        meanfield.Jinteraction(h, Jz1=-1.0, solver="anderson")
+
+
+def test_szsz_sxsx_sysy_return_none_instead_of_crashing_when_unsupported():
+    """SzSz/SxSx/SySy return the NotImplemented sentinel for spinless or
+    BdG Hamiltonians; the get_*_mean_field_hamiltonian wrappers must handle
+    that (returning None) rather than crashing on scf.converged."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=False)
+    assert h.get_szsz_mean_field_hamiltonian(J1=1.0) is None
+    assert h.get_sxsx_mean_field_hamiltonian(J1=1.0) is None
+    assert h.get_sysy_mean_field_hamiltonian(J1=1.0) is None
+    hamiltonian, etot = h.get_szsz_mean_field_hamiltonian(J1=1.0,
+            return_total_energy=True)
+    assert hamiltonian is None and etot is None

--- a/tests/scf/test_spinspin_rotational_symmetry.py
+++ b/tests/scf/test_spinspin_rotational_symmetry.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+
+MAXERROR = 1e-6
+
+_AXIS = {"x": 0, "y": 1, "z": 2}
+_FUNCTION = {"x": meanfield.SxSx, "y": meanfield.SySy, "z": meanfield.SzSz}
+_GUESS = {"x": "ferroX", "y": "ferroY", "z": "ferroZ"}
+
+
+def _run(axis, J1=-2.0, filling=0.2, nk=10):
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    scf = _FUNCTION[axis](h, J1=J1, mf=_GUESS[axis], nk=nk,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=filling)
+    assert scf.converged, f"SCF for axis {axis} did not converge"
+    return scf
+
+
+def test_szsz_sxsx_sysy_are_rotations_of_each_other():
+    """SzSz, SxSx and SySy differ only by which axis the (otherwise
+    identical, spin-degenerate) Sa_i Sa_j interaction picks out. By the
+    SU(2) symmetry of the bare interaction, the self-consistent total
+    energy and the magnitude of the ordered moment must be identical for
+    all three axes -- only the direction of the ordering differs. This is
+    the key cross-check that the SxSx/SySy rotate-solve-rotate-back
+    implementation (see selfconsistency/spinspin.py) has the right
+    rotation angle and sign."""
+    scfs = {axis: _run(axis) for axis in ("x", "y", "z")}
+    etots = np.array([scfs[axis].total_energy for axis in ("x", "y", "z")])
+    assert np.max(np.abs(etots - np.mean(etots))) < 1e-5, \
+        f"Total energies are not rotationally invariant: {etots}"
+    moments = {axis: scfs[axis].hamiltonian.get_magnetization()
+               for axis in ("x", "y", "z")}
+    magnitudes = []
+    for axis in ("x", "y", "z"):
+        m = moments[axis]
+        ordered_component = np.mean(np.abs(m[:, _AXIS[axis]]))
+        other_components = [np.mean(np.abs(m[:, _AXIS[o]]))
+                for o in ("x", "y", "z") if o != axis]
+        magnitudes.append(ordered_component)
+        assert ordered_component > 0.05, \
+            f"axis {axis}: no sizable ordered moment along its own axis"
+        assert max(other_components) < 1e-3, \
+            f"axis {axis}: spurious moment along other axes: {other_components}"
+    magnitudes = np.array(magnitudes)
+    assert np.max(np.abs(magnitudes - np.mean(magnitudes))) < 1e-3, \
+        f"Ordered moment magnitude is not rotationally invariant: {magnitudes}"
+
+
+def test_jinteraction_single_axis_matches_dedicated_function():
+    """Jinteraction with only one of Jx/Jy/Jz nonzero must reproduce the
+    corresponding dedicated SxSx/SySy/SzSz result: the combined SCF loop's
+    per-channel rotate/decouple/rotate-back logic is exactly the same
+    recipe as the single-axis functions, just folded into one loop."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    scf_ref = meanfield.SzSz(h, J1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
+    scf_combined = meanfield.Jinteraction(h, Jz1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
+    assert scf_ref.converged and scf_combined.converged
+    assert np.isclose(scf_ref.total_energy, scf_combined.total_energy,
+            atol=1e-4), \
+            (scf_ref.total_energy, scf_combined.total_energy)
+    m_ref = scf_ref.hamiltonian.get_magnetization()
+    m_combined = scf_combined.hamiltonian.get_magnetization()
+    assert np.mean(np.abs(m_ref - m_combined)) < 1e-3

--- a/tests/scf/test_spinspin_rotational_symmetry.py
+++ b/tests/scf/test_spinspin_rotational_symmetry.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pyqula import geometry
 from pyqula import meanfield
@@ -68,3 +69,34 @@ def test_jinteraction_single_axis_matches_dedicated_function():
     m_ref = scf_ref.hamiltonian.get_magnetization()
     m_combined = scf_combined.hamiltonian.get_magnetization()
     assert np.mean(np.abs(m_ref - m_combined)) < 1e-3
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_jinteraction_random_direction_guess_gives_collinear_moment(seed):
+    """For an isotropic (Jx=Jy=Jz) exchange, the bare interaction has no
+    preferred axis, so the direction the system orders along must be set
+    entirely by the initial guess: a random-direction guess must converge
+    to a moment collinear with it. This is the key regression test for a
+    bug where Jinteraction's per-iteration density-matrix rotation
+    (selfconsistency/spinspin.py's _rotate_dm, used to fold the x/y
+    channels into the lab-frame SCF loop) used the wrong convention and
+    silently flipped the sign of the y Pauli component -- invisible to
+    energy/magnitude-only checks (a pure-y guess still self-consistently
+    finds a same-magnitude, same-energy y-ordered solution even with the
+    sign flipped), but not to a random, generically-3-component direction:
+    before the fix, every direction collapsed onto the x axis instead."""
+    rng = np.random.default_rng(seed)
+    v = rng.random(3) - 0.5
+    v = v/np.linalg.norm(v)
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    guess = h.copy()
+    guess.add_exchange(0.1*v)
+    scf = meanfield.Jinteraction(h, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0, mf=guess,
+            nk=10, maxerror=MAXERROR, mix=0.2, maxite=300, filling=0.2)
+    assert scf.converged
+    m = np.mean(scf.hamiltonian.get_magnetization(), axis=0)
+    assert np.linalg.norm(m) > 0.05, "no sizable ordered moment developed"
+    cos_angle = np.dot(m/np.linalg.norm(m), v)
+    assert cos_angle > 1 - 1e-3, \
+        f"moment {m} is not collinear with guess direction {v} (cos={cos_angle})"

--- a/tests/scf/test_spinspin_rotational_symmetry.py
+++ b/tests/scf/test_spinspin_rotational_symmetry.py
@@ -173,3 +173,29 @@ def test_szsz_sxsx_sysy_return_none_instead_of_crashing_when_unsupported():
     hamiltonian, etot = h.get_szsz_mean_field_hamiltonian(J1=1.0,
             return_total_energy=True)
     assert hamiltonian is None and etot is None
+
+
+def test_jinteraction_and_vjinteraction_also_return_none_when_unsupported():
+    """Jinteraction/VJinteraction must behave the same as their SzSz/SxSx/
+    SySy siblings for a spinless Hamiltonian (return the NotImplemented
+    sentinel / None through the wrapper), not raise -- regression test for
+    an inconsistency where they used to raise ValueError instead."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=False)
+    assert meanfield.Jinteraction(h, Jz1=1.0) is NotImplemented
+    assert meanfield.VJinteraction(h, U=1.0) is NotImplemented
+    assert h.get_exchange_mean_field_hamiltonian(Jz1=1.0) is None
+    assert h.get_combined_mean_field_hamiltonian(U=1.0) is None
+
+
+def test_jinteraction_result_has_V_set():
+    """The Hamiltonian returned by get_exchange_mean_field_hamiltonian must
+    have .V set, like Vinteraction/SzSz/SxSx/SySy's results already do --
+    regression test for a gap where Jinteraction/VJinteraction's SCF loop
+    never set it, leaving h.V as None inconsistently with the rest of the
+    mean-field family."""
+    g = geometry.chain()
+    h = g.get_hamiltonian(has_spin=True)
+    h2 = h.get_exchange_mean_field_hamiltonian(Jz1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, filling=0.2)
+    assert h2.V is not None

--- a/tests/scf/test_spinspin_supercell.py
+++ b/tests/scf/test_spinspin_supercell.py
@@ -1,0 +1,102 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+
+MAXERROR = 1e-6
+
+
+def test_szsz_supercell_matches_minimal_cell():
+    """The self-consistent energy per atom (and magnetization pattern) of
+    an SzSz calculation must be the same whether computed in the minimal
+    (1-atom) cell or an N-times supercell of it -- the physics is the same
+    lattice, just described with a bigger repeated unit. The two k-meshes
+    must be scaled consistently (nk_supercell = nk_minimal/N, so both
+    sample the same physical k-points folded into the smaller BZ) for
+    exact agreement -- an under-resolved or mismatched supercell k-mesh
+    shows up as ordinary k-convergence noise, not a bug."""
+    g = geometry.chain()
+    nk0 = 60
+
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf1 = meanfield.SzSz(h1, J1=-2.0, mf="ferroZ", nk=nk0, maxerror=MAXERROR,
+            mix=0.3, filling=0.2)
+    assert scf1.converged
+    m1 = scf1.hamiltonian.get_magnetization()
+
+    for n in (2, 3):
+        gn = g.get_supercell(n)
+        hn = gn.get_hamiltonian(has_spin=True)
+        scfn = meanfield.SzSz(hn, J1=-2.0, mf="ferroZ", nk=nk0//n,
+                maxerror=MAXERROR, mix=0.3, filling=0.2)
+        assert scfn.converged
+        assert np.isclose(scf1.total_energy, scfn.total_energy/n, atol=1e-5), \
+            (n, scf1.total_energy, scfn.total_energy/n)
+        mn = scfn.hamiltonian.get_magnetization()
+        assert np.allclose(mn, np.tile(m1, (n, 1)), atol=1e-4), (n, m1, mn)
+
+
+def test_jinteraction_supercell_matches_minimal_cell():
+    """Same check as SzSz, for the combined isotropic-exchange SCF loop
+    (Jinteraction), which -- unlike SzSz -- rotates the density matrix
+    per-iteration rather than the whole Hamiltonian, so this exercises a
+    structurally different code path."""
+    g = geometry.chain()
+    nk0 = 40
+
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf1 = meanfield.Jinteraction(h1, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0,
+            mf="ferroZ", nk=nk0, maxerror=MAXERROR, mix=0.2, maxite=300,
+            filling=0.2)
+    assert scf1.converged
+
+    g2 = g.get_supercell(2)
+    h2 = g2.get_hamiltonian(has_spin=True)
+    scf2 = meanfield.Jinteraction(h2, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0,
+            mf="ferroZ", nk=nk0//2, maxerror=MAXERROR, mix=0.2, maxite=300,
+            filling=0.2)
+    assert scf2.converged
+    assert np.isclose(scf1.total_energy, scf2.total_energy/2, atol=1e-5), \
+        (scf1.total_energy, scf2.total_energy/2)
+
+
+def test_vjinteraction_nambu_supercell_consistency():
+    """Same check as the above, for VJinteraction on a BdG (Nambu)
+    Hamiltonian combining an attractive V1 (superconductivity) with a
+    ferromagnetic J1: both the gap and the total energy per atom must
+    match between the primitive (2-site) bichain cell and its 2x (4-site)
+    supercell.
+
+    This is a regression test for a real bug (found via this exact check,
+    and fixed both here and in the shared densitydensity.py code
+    Vinteraction itself uses) in the total-energy computation:
+    get_dc_energy(v, dm) assumes dm's shape matches v's (2n, never
+    Nambu-doubled), but the total energy used to be computed with the
+    full, un-extracted Nambu-sized density matrix for a BdG Hamiltonian --
+    which was NOT supercell-consistent (verified directly: with that bug,
+    energy per atom differed between cell sizes by an amount much larger
+    than the SCF tolerance)."""
+    g = geometry.bichain()
+    nk0 = 40
+
+    def run(gg, nk):
+        h = gg.get_hamiltonian()
+        h.add_exchange([0.3, 0., 0.])
+        h.turn_nambu()
+        return meanfield.VJinteraction(h, V1=-2.0, J1=-1.0, filling=0.3,
+                mf="random", nk=nk, maxerror=MAXERROR, mix=0.15, maxite=1000)
+
+    scf1 = run(g, nk0)
+    assert scf1.converged
+    natoms1 = len(g.r)
+
+    g2 = g.get_supercell(2)
+    scf2 = run(g2, nk0//2)
+    assert scf2.converged
+    natoms2 = len(g2.r)
+    assert natoms2 == 2*natoms1
+
+    assert np.isclose(scf1.hamiltonian.get_gap(), scf2.hamiltonian.get_gap(),
+            atol=1e-3)
+    assert np.isclose(scf1.total_energy/natoms1, scf2.total_energy/natoms2,
+            atol=1e-3), (scf1.total_energy/natoms1, scf2.total_energy/natoms2)

--- a/tests/scf/test_vjinteraction.py
+++ b/tests/scf/test_vjinteraction.py
@@ -8,16 +8,16 @@ MAXERROR = 1e-6
 
 def test_vjinteraction_reduces_to_jinteraction_with_only_J():
     """VJinteraction combines density-density (V/U) and spin-spin exchange
-    (isotropic J1/J2/J3 plus an optional Jx/Jy/Jz anisotropic correction on
-    the first-neighbor shell) mean field into one SCF loop. With
-    V1=V2=V3=U=0 and only Jz set (pure Sz-Sz, since J1 defaults to 0), it
+    (isotropic J1/J2/J3 plus an optional J1x/J1y/J1z anisotropic correction
+    on the first-neighbor shell) mean field into one SCF loop. With
+    V1=V2=V3=U=0 and only J1z set (pure Sz-Sz, since J1 defaults to 0), it
     must reduce exactly to Jinteraction's Jz1-only case."""
     g = geometry.chain()
     h1 = g.get_hamiltonian(has_spin=True)
     scf_j = meanfield.Jinteraction(h1, Jz1=-2.0, mf="ferroZ", nk=10,
             maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
     h2 = g.get_hamiltonian(has_spin=True)
-    scf_vj = meanfield.VJinteraction(h2, Jz=-2.0, mf="ferroZ", nk=10,
+    scf_vj = meanfield.VJinteraction(h2, J1z=-2.0, mf="ferroZ", nk=10,
             maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
     assert scf_j.converged and scf_vj.converged
     assert np.isclose(scf_j.total_energy, scf_vj.total_energy, atol=1e-4), \
@@ -28,7 +28,7 @@ def test_vjinteraction_reduces_to_jinteraction_with_only_J():
 
 
 def test_vjinteraction_reduces_to_vinteraction_with_only_V():
-    """With Jx=Jy=Jz=0, VJinteraction must reduce exactly to Vinteraction
+    """With J1x=J1y=J1z=0, VJinteraction must reduce exactly to Vinteraction
     (here exercised through its U onsite Hubbard term)."""
     g = geometry.chain()
     h1 = g.get_hamiltonian(has_spin=True)
@@ -58,9 +58,9 @@ def test_vjinteraction_combined_U_and_J_reinforce_each_other():
     h_u = g.get_hamiltonian(has_spin=True)
     scf_u = meanfield.VJinteraction(h_u, U=5.0, **params)
     h_j = g.get_hamiltonian(has_spin=True)
-    scf_j = meanfield.VJinteraction(h_j, Jz=-1.0, **params)
+    scf_j = meanfield.VJinteraction(h_j, J1z=-1.0, **params)
     h_uj = g.get_hamiltonian(has_spin=True)
-    scf_uj = meanfield.VJinteraction(h_uj, U=5.0, Jz=-1.0, **params)
+    scf_uj = meanfield.VJinteraction(h_uj, U=5.0, J1z=-1.0, **params)
     assert scf_u.converged and scf_j.converged and scf_uj.converged
 
     mz_u = np.mean(np.abs(scf_u.hamiltonian.get_magnetization()[:, 2]))
@@ -71,10 +71,10 @@ def test_vjinteraction_combined_U_and_J_reinforce_each_other():
         f"(U-only {mz_u}, Jz-only {mz_j})"
 
 
-def test_vjinteraction_J1_matches_setting_Jx_Jy_Jz_equal():
+def test_vjinteraction_J1_matches_setting_J1x_J1y_J1z_equal():
     """J1 (isotropic first-neighbor exchange) must be exactly equivalent to
-    setting Jx=Jy=Jz to the same value with J1=0, since J1 is defined as an
-    isotropic Heisenberg coupling added identically to all three axes on
+    setting J1x=J1y=J1z to the same value with J1=0, since J1 is defined as
+    an isotropic Heisenberg coupling added identically to all three axes on
     the first-neighbor shell."""
     g = geometry.chain()
     params = dict(mf="ferroZ", nk=10, maxerror=MAXERROR, mix=0.3,
@@ -82,7 +82,7 @@ def test_vjinteraction_J1_matches_setting_Jx_Jy_Jz_equal():
     h1 = g.get_hamiltonian(has_spin=True)
     scf_j1 = meanfield.VJinteraction(h1, J1=-2.0, **params)
     h2 = g.get_hamiltonian(has_spin=True)
-    scf_xyz = meanfield.VJinteraction(h2, Jx=-2.0, Jy=-2.0, Jz=-2.0, **params)
+    scf_xyz = meanfield.VJinteraction(h2, J1x=-2.0, J1y=-2.0, J1z=-2.0, **params)
     assert scf_j1.converged and scf_xyz.converged
     assert np.isclose(scf_j1.total_energy, scf_xyz.total_energy, atol=1e-4), \
         (scf_j1.total_energy, scf_xyz.total_energy)
@@ -93,7 +93,7 @@ def test_vjinteraction_J1_matches_setting_Jx_Jy_Jz_equal():
 
 def test_vjinteraction_isotropic_combination_preserves_su2_symmetry():
     """U (already SU(2)-symmetric) combined with an isotropic J1 exchange
-    (Jx=Jy=Jz=0, the pure Heisenberg case) must still have full SU(2)
+    (J1x=J1y=J1z=0, the pure Heisenberg case) must still have full SU(2)
     symmetry: a random-direction initial guess must converge to a moment
     collinear with it, with no hidden preferred axis introduced by how the
     two channels are summed into one z-channel matrix (see

--- a/tests/scf/test_vjinteraction.py
+++ b/tests/scf/test_vjinteraction.py
@@ -8,14 +8,16 @@ MAXERROR = 1e-6
 
 def test_vjinteraction_reduces_to_jinteraction_with_only_J():
     """VJinteraction combines density-density (V/U) and spin-spin exchange
-    (Jx/Jy/Jz) mean field into one SCF loop. With V1=V2=V3=U=0, it must
-    reduce exactly to Jinteraction."""
+    (isotropic J1/J2/J3 plus an optional Jx/Jy/Jz anisotropic correction on
+    the first-neighbor shell) mean field into one SCF loop. With
+    V1=V2=V3=U=0 and only Jz set (pure Sz-Sz, since J1 defaults to 0), it
+    must reduce exactly to Jinteraction's Jz1-only case."""
     g = geometry.chain()
     h1 = g.get_hamiltonian(has_spin=True)
     scf_j = meanfield.Jinteraction(h1, Jz1=-2.0, mf="ferroZ", nk=10,
             maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
     h2 = g.get_hamiltonian(has_spin=True)
-    scf_vj = meanfield.VJinteraction(h2, Jz1=-2.0, mf="ferroZ", nk=10,
+    scf_vj = meanfield.VJinteraction(h2, Jz=-2.0, mf="ferroZ", nk=10,
             maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
     assert scf_j.converged and scf_vj.converged
     assert np.isclose(scf_j.total_energy, scf_vj.total_energy, atol=1e-4), \
@@ -56,9 +58,9 @@ def test_vjinteraction_combined_U_and_J_reinforce_each_other():
     h_u = g.get_hamiltonian(has_spin=True)
     scf_u = meanfield.VJinteraction(h_u, U=5.0, **params)
     h_j = g.get_hamiltonian(has_spin=True)
-    scf_j = meanfield.VJinteraction(h_j, Jz1=-1.0, **params)
+    scf_j = meanfield.VJinteraction(h_j, Jz=-1.0, **params)
     h_uj = g.get_hamiltonian(has_spin=True)
-    scf_uj = meanfield.VJinteraction(h_uj, U=5.0, Jz1=-1.0, **params)
+    scf_uj = meanfield.VJinteraction(h_uj, U=5.0, Jz=-1.0, **params)
     assert scf_u.converged and scf_j.converged and scf_uj.converged
 
     mz_u = np.mean(np.abs(scf_u.hamiltonian.get_magnetization()[:, 2]))
@@ -69,12 +71,33 @@ def test_vjinteraction_combined_U_and_J_reinforce_each_other():
         f"(U-only {mz_u}, Jz-only {mz_j})"
 
 
+def test_vjinteraction_J1_matches_setting_Jx_Jy_Jz_equal():
+    """J1 (isotropic first-neighbor exchange) must be exactly equivalent to
+    setting Jx=Jy=Jz to the same value with J1=0, since J1 is defined as an
+    isotropic Heisenberg coupling added identically to all three axes on
+    the first-neighbor shell."""
+    g = geometry.chain()
+    params = dict(mf="ferroZ", nk=10, maxerror=MAXERROR, mix=0.3,
+            maxite=300, filling=0.2)
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf_j1 = meanfield.VJinteraction(h1, J1=-2.0, **params)
+    h2 = g.get_hamiltonian(has_spin=True)
+    scf_xyz = meanfield.VJinteraction(h2, Jx=-2.0, Jy=-2.0, Jz=-2.0, **params)
+    assert scf_j1.converged and scf_xyz.converged
+    assert np.isclose(scf_j1.total_energy, scf_xyz.total_energy, atol=1e-4), \
+        (scf_j1.total_energy, scf_xyz.total_energy)
+    m1 = scf_j1.hamiltonian.get_magnetization()
+    m2 = scf_xyz.hamiltonian.get_magnetization()
+    assert np.mean(np.abs(m1 - m2)) < 1e-3
+
+
 def test_vjinteraction_isotropic_combination_preserves_su2_symmetry():
-    """U (already SU(2)-symmetric) combined with an isotropic (Jx=Jy=Jz)
-    exchange must still have full SU(2) symmetry: a random-direction
-    initial guess must converge to a moment collinear with it, with no
-    hidden preferred axis introduced by how the two channels are summed
-    into one z-channel matrix (see VJinteraction/_build_density_v)."""
+    """U (already SU(2)-symmetric) combined with an isotropic J1 exchange
+    (Jx=Jy=Jz=0, the pure Heisenberg case) must still have full SU(2)
+    symmetry: a random-direction initial guess must converge to a moment
+    collinear with it, with no hidden preferred axis introduced by how the
+    two channels are summed into one z-channel matrix (see
+    VJinteraction/_build_density_v)."""
     g = geometry.chain()
     rng = np.random.default_rng(3)
     for _ in range(4):
@@ -83,7 +106,7 @@ def test_vjinteraction_isotropic_combination_preserves_su2_symmetry():
         h = g.get_hamiltonian(has_spin=True)
         guess = h.copy()
         guess.add_exchange(0.1*v)
-        scf = meanfield.VJinteraction(h, U=1.0, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0,
+        scf = meanfield.VJinteraction(h, U=1.0, J1=-2.0,
                 mf=guess, nk=10, maxerror=MAXERROR, mix=0.2, maxite=300,
                 filling=0.2)
         assert scf.converged

--- a/tests/scf/test_vjinteraction.py
+++ b/tests/scf/test_vjinteraction.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+
+MAXERROR = 1e-6
+
+
+def test_vjinteraction_reduces_to_jinteraction_with_only_J():
+    """VJinteraction combines density-density (V/U) and spin-spin exchange
+    (Jx/Jy/Jz) mean field into one SCF loop. With V1=V2=V3=U=0, it must
+    reduce exactly to Jinteraction."""
+    g = geometry.chain()
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf_j = meanfield.Jinteraction(h1, Jz1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
+    h2 = g.get_hamiltonian(has_spin=True)
+    scf_vj = meanfield.VJinteraction(h2, Jz1=-2.0, mf="ferroZ", nk=10,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
+    assert scf_j.converged and scf_vj.converged
+    assert np.isclose(scf_j.total_energy, scf_vj.total_energy, atol=1e-4), \
+        (scf_j.total_energy, scf_vj.total_energy)
+    m_j = scf_j.hamiltonian.get_magnetization()
+    m_vj = scf_vj.hamiltonian.get_magnetization()
+    assert np.mean(np.abs(m_j - m_vj)) < 1e-3
+
+
+def test_vjinteraction_reduces_to_vinteraction_with_only_V():
+    """With Jx=Jy=Jz=0, VJinteraction must reduce exactly to Vinteraction
+    (here exercised through its U onsite Hubbard term)."""
+    g = geometry.chain()
+    h1 = g.get_hamiltonian(has_spin=True)
+    scf_v = meanfield.Vinteraction(h1, U=10.0, mf="ferro", nk=10,
+            maxerror=MAXERROR, mix=0.3, filling=0.2)
+    h2 = g.get_hamiltonian(has_spin=True)
+    scf_vj = meanfield.VJinteraction(h2, U=10.0, mf="ferro", nk=10,
+            maxerror=MAXERROR, mix=0.3, maxite=300, filling=0.2)
+    assert scf_v.converged and scf_vj.converged
+    assert np.isclose(scf_v.total_energy, scf_vj.total_energy, atol=1e-4), \
+        (scf_v.total_energy, scf_vj.total_energy)
+    m_v = scf_v.hamiltonian.get_magnetization()
+    m_vj = scf_vj.hamiltonian.get_magnetization()
+    assert np.mean(np.abs(m_v - m_vj)) < 1e-3
+
+
+def test_vjinteraction_combined_U_and_J_reinforce_each_other():
+    """A sanity check that both channels genuinely contribute when combined:
+    U (onsite Hubbard, favors a moment along any direction) and a
+    ferromagnetic Jz (favors z order specifically) should reinforce each
+    other, giving a larger z moment than either alone at the same
+    strength."""
+    g = geometry.chain()
+    params = dict(mf="ferroZ", nk=10, maxerror=MAXERROR, mix=0.2,
+            maxite=400, filling=0.2)
+
+    h_u = g.get_hamiltonian(has_spin=True)
+    scf_u = meanfield.VJinteraction(h_u, U=5.0, **params)
+    h_j = g.get_hamiltonian(has_spin=True)
+    scf_j = meanfield.VJinteraction(h_j, Jz1=-1.0, **params)
+    h_uj = g.get_hamiltonian(has_spin=True)
+    scf_uj = meanfield.VJinteraction(h_uj, U=5.0, Jz1=-1.0, **params)
+    assert scf_u.converged and scf_j.converged and scf_uj.converged
+
+    mz_u = np.mean(np.abs(scf_u.hamiltonian.get_magnetization()[:, 2]))
+    mz_j = np.mean(np.abs(scf_j.hamiltonian.get_magnetization()[:, 2]))
+    mz_uj = np.mean(np.abs(scf_uj.hamiltonian.get_magnetization()[:, 2]))
+    assert mz_uj > max(mz_u, mz_j), \
+        f"combined moment ({mz_uj}) should exceed either channel alone " \
+        f"(U-only {mz_u}, Jz-only {mz_j})"
+
+
+def test_vjinteraction_isotropic_combination_preserves_su2_symmetry():
+    """U (already SU(2)-symmetric) combined with an isotropic (Jx=Jy=Jz)
+    exchange must still have full SU(2) symmetry: a random-direction
+    initial guess must converge to a moment collinear with it, with no
+    hidden preferred axis introduced by how the two channels are summed
+    into one z-channel matrix (see VJinteraction/_build_density_v)."""
+    g = geometry.chain()
+    rng = np.random.default_rng(3)
+    for _ in range(4):
+        v = rng.random(3) - 0.5
+        v = v/np.linalg.norm(v)
+        h = g.get_hamiltonian(has_spin=True)
+        guess = h.copy()
+        guess.add_exchange(0.1*v)
+        scf = meanfield.VJinteraction(h, U=1.0, Jx1=-2.0, Jy1=-2.0, Jz1=-2.0,
+                mf=guess, nk=10, maxerror=MAXERROR, mix=0.2, maxite=300,
+                filling=0.2)
+        assert scf.converged
+        m = np.mean(scf.hamiltonian.get_magnetization(), axis=0)
+        assert np.linalg.norm(m) > 0.05
+        cos_angle = np.dot(m/np.linalg.norm(m), v)
+        assert cos_angle > 1 - 1e-3, \
+            f"moment {m} not collinear with guess {v} (cos={cos_angle})"


### PR DESCRIPTION
## Summary
- New `selfconsistency/spinspin.py`: `SzSz` reuses the existing density-density Hartree-Fock engine directly (Sz_i Sz_j is itself a density-density interaction in the spin-orbital basis, with a +/-1/4 sign pattern instead of Vinteraction's uniform value). `SxSx`/`SySy` rotate the problem so the target axis becomes the computational z axis, solve there, and rotate the converged Hamiltonian back. `Jinteraction` combines all three axes (Jx/Jy/Jz) into a single anisotropic-exchange SCF loop.
- Exposed as `meanfield.SzSz/SxSx/SySy/Jinteraction` and as `Hamiltonian` methods `get_szsz_mean_field_hamiltonian` / `get_sxsx_mean_field_hamiltonian` / `get_sysy_mean_field_hamiltonian` / `get_exchange_mean_field_hamiltonian`, mirroring `get_mean_field_hamiltonian`.
- Fixes a pre-existing bug in `rotate_spin.global_spin_rotation` (scipy `bmat` raised "blocks must be 2-D" for single-atom-per-cell lattices) -- exactly the case the SxSx/SySy rotation trick needs, uncovered while testing this feature on a monatomic chain.
- Documentation: new "Spin-spin exchange interactions" section in `documentation/user_guide.md` with runnable snippets, plus reference entries for the new methods, and a README FUNCTIONALITIES line.

## Test plan
- New `tests/scf/test_spinspin_rotational_symmetry.py`: the key cross-check -- SzSz/SxSx/SySy at the same coupling on a chain give identical total energy and moment magnitude, differing only in which axis orders (verifies the rotation angle/sign is correct); also checks `Jinteraction` with a single axis active matches the dedicated single-axis function.
- New `tests/scf/test_spinspin_ferro_chain.py`: the ferromagnetic Sz-Sz moment grows with coupling strength (sign-convention sanity check).
- Full existing suite (`python -m pytest tests`) re-run: 317 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAoiDzJuVjGZWgHRDU1GW