### PR TITLE
SCF hot-path speedups: JIT cache, zero-channel skip, sparse dm, Fermi dedup, block rotation

### DIFF
--- a/src/pyqula/densitymatrix.py
+++ b/src/pyqula/densitymatrix.py
@@ -112,19 +112,77 @@ def full_dm_accumulate_sparse(h,pairs,nk=10,fermi=0.0,
         mats = np.array([hk(k) for k in kbatch]) # k-Hamiltonians in this batch
         es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize in parallel
         es_batch = es_batch-fermi # substract fermi energy
-        for d,(rows,cols) in pairs.items():
-            npairs = len(rows)
-            if npairs==0: continue # nothing requested in this direction
-            if npairs>threshold: # dense direction: the plain matmul wins
-                contribs = full_dm_batch_d_vectorized(es_batch,vs_batch,kbatch,
-                        np.array(d,dtype=np.float64),delta=delta)
-                outd[d] += np.sum(contribs,axis=0) # pool the batch
-            else:
-                contribs = full_dm_batch_d_sparse(es_batch,vs_batch,kbatch,
-                        np.array(d,dtype=np.float64),rows,cols,delta=delta)
-                outd[d][rows,cols] += np.sum(contribs,axis=0) # pool the batch
+        _accumulate_dm_batch(outd,pairs,threshold,es_batch,vs_batch,kbatch,delta)
     for d in outd: outd[d] *= fac # renormalize
     return outd
+
+
+def _accumulate_dm_batch(outd,pairs,threshold,es_batch,vs_batch,kbatch,delta):
+    """Add one k-batch's contribution to outd (in place), choosing the
+    sparse or dense kernel per direction -- the shared per-batch step of
+    full_dm_accumulate_sparse and full_dm_accumulate_sparse_with_fermi."""
+    for d,(rows,cols) in pairs.items():
+        npairs = len(rows)
+        if npairs==0: continue # nothing requested in this direction
+        if npairs>threshold: # dense direction: the plain matmul wins
+            contribs = full_dm_batch_d_vectorized(es_batch,vs_batch,kbatch,
+                    np.array(d,dtype=np.float64),delta=delta)
+            outd[d] += np.sum(contribs,axis=0) # pool the batch
+        else:
+            contribs = full_dm_batch_d_sparse(es_batch,vs_batch,kbatch,
+                    np.array(d,dtype=np.float64),rows,cols,delta=delta)
+            outd[d][rows,cols] += np.sum(contribs,axis=0) # pool the batch
+
+
+def full_dm_accumulate_sparse_with_fermi(h,pairs,filling,nk=10,
+        delta=delta_dm,batch_size=16,dense_fraction=0.01):
+    """Like full_dm_accumulate_sparse, but also determines and returns the
+    Fermi energy for `filling` from the SAME diagonalization used to build
+    the density matrix, instead of paying for a second, independent
+    diagonalization sweep first the way
+    selfconsistency.spinspin._run_anisotropic_scf's callback_h
+    (Hamiltonian.get_fermi4filling) otherwise would before calling
+    get_dm/full_dm_accumulate_sparse on the (separately, again-diagonalized)
+    shifted Hamiltonian. Shifting a Hamiltonian by a constant
+    (H' = H - fermi*I) does not change its eigenVECTORS, only shifts the
+    eigenvalues by that same constant -- so diagonalizing the UNSHIFTED h
+    once, determining fermi from the pooled eigenvalues, then subtracting
+    it from the already-computed eigenvalues before building the density
+    matrix, is exactly equivalent to the two-diagonalization version, at
+    (up to) half the diagonalization cost.
+
+    Unlike full_dm_accumulate_sparse's own batching (which only ever needs
+    one batch of eigenvectors in memory at a time, since fermi is already
+    known there), this holds every batch's (es,vs,kbatch) for the whole
+    k-mesh at once, since the Fermi energy needs every eigenvalue in the
+    mesh before any density-matrix contribution can be computed. Used only
+    by selfconsistency.spinspin._run_anisotropic_scf for the normal-state
+    (has_eh=False) case with mu=None (a Fermi-level search is actually
+    needed) -- see that function's docstring for why the Nambu case is out
+    of scope: BdG's own get_fermi4filling diagonalizes an entirely
+    different (de-paired) Hamiltonian, not just a shifted copy of the one
+    the density matrix comes from, so this trick does not apply there."""
+    from .htk.eigenvectors import parallel_diagonalization
+    from .filling import get_fermi_energy
+    hk = h.get_hk_gen() # get the Hamiltonian generator
+    ks = np.array(h.geometry.get_kmesh(nk=nk)) # get the mesh
+    fac = 1./len(ks) # normalization
+    n = h.intra.shape[0]
+    threshold = dense_fraction*n*n
+    batches = [] # (es_batch, vs_batch, kbatch) for the whole mesh
+    all_es = []
+    for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
+        kbatch = ks[i0:i0+batch_size]
+        mats = np.array([hk(k) for k in kbatch]) # k-Hamiltonians in this batch
+        es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize in parallel
+        batches.append((es_batch,vs_batch,kbatch))
+        all_es.append(es_batch.ravel())
+    fermi = get_fermi_energy(np.concatenate(all_es),filling)
+    outd = {d: np.zeros((n,n),dtype=np.complex128) for d in pairs}
+    for es_batch,vs_batch,kbatch in batches:
+        _accumulate_dm_batch(outd,pairs,threshold,es_batch-fermi,vs_batch,kbatch,delta)
+    for d in outd: outd[d] *= fac # renormalize
+    return outd,fermi
 
 
 def full_dm_simultaneous(h,nk=10,fermi=0.0,

--- a/src/pyqula/densitymatrix.py
+++ b/src/pyqula/densitymatrix.py
@@ -135,7 +135,7 @@ def _accumulate_dm_batch(outd,pairs,threshold,es_batch,vs_batch,kbatch,delta):
 
 
 def full_dm_accumulate_sparse_with_fermi(h,pairs,filling,nk=10,
-        delta=delta_dm,batch_size=16,dense_fraction=0.01):
+        delta=delta_dm,batch_size=16,dense_fraction=0.01,max_memory_gb=2.0):
     """Like full_dm_accumulate_sparse, but also determines and returns the
     Fermi energy for `filling` from the SAME diagonalization used to build
     the density matrix, instead of paying for a second, independent
@@ -155,19 +155,38 @@ def full_dm_accumulate_sparse_with_fermi(h,pairs,filling,nk=10,
     one batch of eigenvectors in memory at a time, since fermi is already
     known there), this holds every batch's (es,vs,kbatch) for the whole
     k-mesh at once, since the Fermi energy needs every eigenvalue in the
-    mesh before any density-matrix contribution can be computed. Used only
-    by selfconsistency.spinspin._run_anisotropic_scf for the normal-state
-    (has_eh=False) case with mu=None (a Fermi-level search is actually
-    needed) -- see that function's docstring for why the Nambu case is out
-    of scope: BdG's own get_fermi4filling diagonalizes an entirely
-    different (de-paired) Hamiltonian, not just a shifted copy of the one
-    the density matrix comes from, so this trick does not apply there."""
+    mesh before any density-matrix contribution can be computed -- unlike
+    full_dm_accumulate's own batch_size, which bounds memory "regardless of
+    how dense the k-mesh is" (that function's own docstring), this one does
+    not, and the eigenvector memory for the whole mesh can get large for an
+    unusually fine k-mesh (e.g. ~6GB for a 196-orbital system on a 100x100
+    2D mesh). max_memory_gb guards against that: above it, this falls back
+    to the same batch_size-bounded, memory-safe (but two-diagonalization)
+    sequence full_dm_accumulate_sparse's own caller used before this
+    function existed -- get_fermi4filling on `h` directly, then
+    full_dm_accumulate_sparse on a shifted copy -- trading back the
+    dedup for a bounded memory footprint only in that regime.
+
+    Used only by selfconsistency.spinspin._run_anisotropic_scf for the
+    normal-state (has_eh=False) case with mu=None (a Fermi-level search is
+    actually needed) -- see that function's docstring for why the Nambu
+    case is out of scope: BdG's own get_fermi4filling diagonalizes an
+    entirely different (de-paired) Hamiltonian, not just a shifted copy of
+    the one the density matrix comes from, so this trick does not apply
+    there."""
     from .htk.eigenvectors import parallel_diagonalization
     from .filling import get_fermi_energy
-    hk = h.get_hk_gen() # get the Hamiltonian generator
     ks = np.array(h.geometry.get_kmesh(nk=nk)) # get the mesh
-    fac = 1./len(ks) # normalization
     n = h.intra.shape[0]
+    if len(ks)*n*n*16 > max_memory_gb*1e9: # see max_memory_gb's docstring
+        fermi = h.get_fermi4filling(filling,nk=nk)
+        h_shifted = h.copy()
+        h_shifted.shift_fermi(-fermi)
+        dm = full_dm_accumulate_sparse(h_shifted,pairs,nk=nk,delta=delta,
+                batch_size=batch_size,dense_fraction=dense_fraction)
+        return dm,fermi
+    hk = h.get_hk_gen() # get the Hamiltonian generator
+    fac = 1./len(ks) # normalization
     threshold = dense_fraction*n*n
     batches = [] # (es_batch, vs_batch, kbatch) for the whole mesh
     all_es = []

--- a/src/pyqula/densitymatrix.py
+++ b/src/pyqula/densitymatrix.py
@@ -67,6 +67,66 @@ def full_dm_accumulate(h,nk=10,fermi=0.0,
     
 
 
+def full_dm_accumulate_sparse(h,pairs,nk=10,fermi=0.0,
+        delta=delta_dm,batch_size=16,dense_fraction=0.01):
+    """Sparse-position counterpart of full_dm_accumulate: for each
+    direction, only computes the (row,col) entries listed in pairs[d]
+    instead of the full (n,n) matrix (see dmtk.fulldm.full_dm_batch_d_sparse
+    and selfconsistency.spinspin._build_sparse_pairs for why this is safe
+    -- a short-range interaction matrix v[d] is mostly zero, so most of a
+    full (n,n) density matrix at that direction is never read downstream).
+    Still returns a dense {direction: (n,n)} dict, zero everywhere except
+    at the requested pairs (or fully populated, for a direction that fell
+    back to the dense kernel -- see dense_fraction), so it is a drop-in
+    replacement for full_dm_accumulate(...,ds=list(pairs)) wherever only
+    those entries are consumed -- used only by
+    selfconsistency.spinspin._run_anisotropic_scf (Jinteraction/
+    VJinteraction's shared SCF core), not by the generic (Vinteraction/
+    SzSz/SxSx/SySy) path, which still gets the full matrix via
+    full_dm_accumulate.
+
+    dense_fraction: per-direction fallback threshold. full_dm_batch_d_sparse
+    does asymptotically less work than the dense (n,n)@(n,n) matmul
+    (full_dm_batch_d_vectorized) for a truly sparse direction, but it is a
+    gather + elementwise-multiply-and-reduce, not a BLAS call, so its
+    per-entry constant is much worse than a matmul's -- measured on a
+    196-orbital system, the sparse kernel is ~7x *slower* than the dense
+    one at 8.8% of n^2 requested entries (a common density for a bond
+    direction that happens to fold entirely within one cell, e.g.
+    second-neighbor bonds in a compact supercell) despite doing an order of
+    magnitude fewer FLOPs, and the crossover is around 1-2% of n^2. Below
+    dense_fraction*n^2 requested entries for a direction, use the sparse
+    kernel and scatter its output into the (initially zero) container;
+    above it, just run the dense kernel for that direction and keep its
+    full result -- strictly more information than requested, but correct
+    and, past the crossover, cheaper too."""
+    from .htk.eigenvectors import parallel_diagonalization
+    hk = h.get_hk_gen() # get the Hamiltonian generator
+    ks = np.array(h.geometry.get_kmesh(nk=nk)) # get the mesh
+    fac = 1./len(ks) # normalization
+    n = h.intra.shape[0]
+    threshold = dense_fraction*n*n
+    outd = {d: np.zeros((n,n),dtype=np.complex128) for d in pairs}
+    for i0 in range(0,len(ks),batch_size): # loop over batches of kpoints
+        kbatch = ks[i0:i0+batch_size]
+        mats = np.array([hk(k) for k in kbatch]) # k-Hamiltonians in this batch
+        es_batch,vs_batch = parallel_diagonalization(mats) # diagonalize in parallel
+        es_batch = es_batch-fermi # substract fermi energy
+        for d,(rows,cols) in pairs.items():
+            npairs = len(rows)
+            if npairs==0: continue # nothing requested in this direction
+            if npairs>threshold: # dense direction: the plain matmul wins
+                contribs = full_dm_batch_d_vectorized(es_batch,vs_batch,kbatch,
+                        np.array(d,dtype=np.float64),delta=delta)
+                outd[d] += np.sum(contribs,axis=0) # pool the batch
+            else:
+                contribs = full_dm_batch_d_sparse(es_batch,vs_batch,kbatch,
+                        np.array(d,dtype=np.float64),rows,cols,delta=delta)
+                outd[d][rows,cols] += np.sum(contribs,axis=0) # pool the batch
+    for d in outd: outd[d] *= fac # renormalize
+    return outd
+
+
 def full_dm_simultaneous(h,nk=10,fermi=0.0,
         delta=delta_dm,
         ds=None):
@@ -98,6 +158,7 @@ def full_dm_simultaneous(h,nk=10,fermi=0.0,
 from .dmtk.fulldm import full_dm_python
 from .dmtk.fulldm import full_dm_python_d
 from .dmtk.fulldm import full_dm_batch_vectorized
+from .dmtk.fulldm import full_dm_batch_d_sparse
 from .dmtk.fulldm import full_dm_batch_d_vectorized
 
 

--- a/src/pyqula/dmtk/fulldm.py
+++ b/src/pyqula/dmtk/fulldm.py
@@ -35,7 +35,7 @@ def full_dm_python_d(es,vs,ks,d,delta=1e-7):
 
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def full_dm_explicit(n,es,vs,delta=1e-7):
   """Auxiliary function to compute the density matrix"""
   dm = np.zeros((n,n),dtype=np.complex128)
@@ -48,14 +48,14 @@ def full_dm_explicit(n,es,vs,delta=1e-7):
 
 
 # vectorized version, lets see if it is faster
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def full_dm_vectorized(es, vs, delta=1e-7):
     occ = 1.0 / (1.0 + np.exp(es / delta))          # shape (len_es,)
     dm = np.conj(vs).T @ (occ[:, None] * vs)        # (n, n) complex
     return dm
 
 
-@jit(nopython=True,parallel=True)
+@jit(nopython=True,parallel=True,cache=True)
 def full_dm_batch_vectorized(es_batch,vs_batch,delta=1e-7):
     """Density-matrix contribution for a batch of kpoints, one kpoint per
     numba thread. vs_batch has shape (nb,n,n) with columns as
@@ -79,7 +79,7 @@ def full_dm_batch_vectorized(es_batch,vs_batch,delta=1e-7):
 
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def full_dm_python_d_jit(n,es,vs,ks,d,delta=1e-7):
   """Auxiliary function to compute the density matrix"""
   dm = np.zeros((n,n),dtype=np.complex128)
@@ -116,7 +116,7 @@ def full_dm_d_python_vectorized(es, vs, ks, d, delta=1e-7):
 
 
 # vectorized version, this should be faster
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def full_dm_d_vectorized(es, vs, ks, d, delta=1e-7):
     # vs must be shape (n, M)
     M = es.shape[0]
@@ -128,7 +128,7 @@ def full_dm_d_vectorized(es, vs, ks, d, delta=1e-7):
     return (np.conj(vs.T) * weight) @ vs   # (n, n)
 
 
-@jit(nopython=True,parallel=True)
+@jit(nopython=True,parallel=True,cache=True)
 def full_dm_batch_d_vectorized(es_batch,vs_batch,ks_batch,d,delta=1e-7):
     """Same as full_dm_batch_vectorized, but weighting each kpoint's
     contribution by the Bloch phase exp(2*pi*i*k.d) for a single hopping

--- a/src/pyqula/dmtk/fulldm.py
+++ b/src/pyqula/dmtk/fulldm.py
@@ -146,3 +146,34 @@ def full_dm_batch_d_vectorized(es_batch,vs_batch,ks_batch,d,delta=1e-7):
         weight = occ*phase
         out[ik] = (np.conj(w)*weight) @ w.T
     return out
+
+
+@jit(nopython=True,parallel=True,cache=True)
+def full_dm_batch_d_sparse(es_batch,vs_batch,ks_batch,d,rows,cols,delta=1e-7):
+    """Same as full_dm_batch_d_vectorized, but only computes the
+    (rows[p],cols[p]) entries of the (n,n) density matrix instead of all
+    n^2 of them -- for a short-range interaction matrix v[d], the vast
+    majority of those n^2 entries are never read by normal_term_ii/jj/ij/ji
+    (selfconsistency/densitydensity.py) because v[d][i,j] is zero there, so
+    computing them via the full (n,n)@(n,n) matmul in
+    full_dm_batch_d_vectorized is mostly wasted work -- see
+    selfconsistency.spinspin._build_sparse_pairs, which derives rows/cols
+    from v's own nonzero pattern (union across the active exchange/density
+    channels, since they share this same k-mesh diagonalization). Returns
+    (nb,npairs) instead of (nb,n,n); the caller scatters these back into a
+    dense (n,n) container at (rows[p],cols[p])."""
+    nb = es_batch.shape[0]
+    npairs = rows.shape[0]
+    out = np.zeros((nb,npairs),dtype=np.complex128)
+    for ik in prange(nb): # loop over kpoints in the batch, in parallel
+        es = es_batch[ik]
+        w = vs_batch[ik]
+        k = ks_batch[ik]
+        kd = k[0]*d[0]+k[1]*d[1]+k[2]*d[2]
+        phase = np.exp(1j*2.0*np.pi*kd)
+        occ = 1.0/(1.0+np.exp(es/delta))
+        weight = occ*phase
+        wa = w[rows,:] # (npairs, nstates)
+        wb = w[cols,:] # (npairs, nstates)
+        out[ik,:] = np.sum(np.conj(wa)*weight*wb,axis=1)
+    return out

--- a/src/pyqula/htk/bloch.py
+++ b/src/pyqula/htk/bloch.py
@@ -35,7 +35,7 @@ def bloch_matrix_generator(ms,ds,dim=1,use_jax=False):
         return f
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def evaluate_bloch_matrix_jit(ms,ds,k):
     """Evaluate the Bloch Hamiltonian"""
     out = ms[0]*0. # initialize

--- a/src/pyqula/htk/eigenvectors.py
+++ b/src/pyqula/htk/eigenvectors.py
@@ -76,7 +76,7 @@ def get_eigenvectors(h,nk=10,kpoints=False,k=None,sparse=False,
 from numba import jit,prange
 import numpy.linalg as nlg
 
-@jit(nopython=True,parallel=True)
+@jit(nopython=True,parallel=True,cache=True)
 def parallel_diagonalization(hks):
     """Diagonalize many matrices at once"""
     n = hks.shape[1] # size of the Hamiltonian
@@ -94,7 +94,7 @@ def parallel_diagonalization(hks):
 
 peigh = parallel_diagonalization # alias
 
-@jit(nopython=True,parallel=True)
+@jit(nopython=True,parallel=True,cache=True)
 def peigvalsh(hks):
     """Diagonalize many matrices at once in parallel"""
     n = hks.shape[1] # size of the Hamiltonian

--- a/src/pyqula/selfconsistency/densitydensity.py
+++ b/src/pyqula/selfconsistency/densitydensity.py
@@ -55,7 +55,7 @@ def normal_term_ji(v,dm):
     out = dm*0.0 # initialize
     return normal_term_ji_jit(v,dm,out) # return the normal term
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def normal_term_jit(v,dm,out):
     """Return the normal terms, jit function"""
     n = len(v[0])
@@ -68,7 +68,7 @@ def normal_term_jit(v,dm,out):
     return out
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def normal_term_ii_jit(v,dm,out):
     """Return the normal terms, jit function"""
     n = len(v[0])
@@ -77,7 +77,7 @@ def normal_term_ii_jit(v,dm,out):
         out[i,i] = out[i,i] + v[i,j]*dm[j,j]
     return out
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def normal_term_jj_jit(v,dm,out):
     """Return the normal terms, jit function"""
     n = len(v[0])
@@ -87,7 +87,7 @@ def normal_term_jj_jit(v,dm,out):
     return out
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def normal_term_ij_jit(v,dm,out):
     """Return the normal terms, jit function"""
     n = len(v[0])
@@ -97,7 +97,7 @@ def normal_term_ij_jit(v,dm,out):
     return out
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def normal_term_ji_jit(v,dm,out):
     """Return the normal terms, jit function"""
     n = len(v[0])
@@ -256,7 +256,7 @@ from .superscf import enforce_eh_symmetry_anomalous
 
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def get_dc_energy_jit(v,dm00,dmd):
     """Double-counting energy contribution of a single interaction key,
     jit function -- the O(n^2) inner loop of get_dc_energy, split out so it

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -371,6 +371,74 @@ def _channel_is_zero(v):
     return all(not np.any(m) for m in v.values())
 
 
+def _build_sparse_pairs(vlist, keys, n):
+    """For each direction, the union of (row,col) index pairs actually read
+    downstream from the lab-frame density matrix, across the given
+    interaction matrices (whichever of vz/vx/vy/vd are not None):
+
+    - get_mf_normal's density-density (compute_dd) term only ever reads
+      dm[(0,0,0)]'s DIAGONAL, for whichever sites participate in any bond
+      of any channel -- in practice that is normally every site, so this
+      always includes the full diagonal at (0,0,0) unconditionally, rather
+      than trying to track which subset that is. Crucially this means the
+      full 2x2 SPIN BLOCK at each site, not just its two purely-diagonal
+      (up-up, down-down) entries: whenever vx/vy is active, _rot_dm rotates
+      dme_lab[(0,0,0)] before compute_dd reads its (rotated) diagonal, and
+      a spin rotation mixes a 2x2 block's diagonal and off-diagonal entries
+      together (rot @ [[a,b],[c,d]] @ rot^dagger's [0,0]/[1,1] entries
+      depend on b,c too) -- so leaving a site's up-down/down-up entries at
+      zero when no channel happens to touch them silently corrupts the
+      rotated diagonal too, not just the (unused) unrotated off-diagonal.
+      Caught by test_jinteraction_random_direction_guess_gives_collinear_moment
+      (isotropic exchange collapsing onto the z axis instead of the guess
+      direction -- the x/y mean-field contribution was being silently
+      zeroed by this).
+    - get_mf_normal's cross term (compute_cross) reads dm[d2][j,i] (note
+      the swapped indices) for every (i,j) where v[d][i,j] is nonzero, i.e.
+      it needs the TRANSPOSE of v[d]'s nonzero pattern at the OPPOSITE
+      direction d2=-d, not v[d2]'s own pattern -- so each v[d] contributes
+      to two masks: its own pattern at d (used directly by get_dc_energy
+      and as the rotation input for vx/vy), and its transpose at d2.
+    - _rot_dm/_rot_dict (used for vx/vy) rotate whichever 2x2 spin
+      sub-blocks are present as a unit (R is block-diagonal in the 2x2
+      spin index, see build_rotation_matrix), so correctness requires
+      each touched site-pair's full 2x2 block, not individual entries.
+      _build_v/_build_density_v's own construction always populates a
+      site-pair's 4 spin sub-entries together (or, for the onsite-U cross
+      term specifically, only the 2 off-diagonal ones -- but those live at
+      a diagonal site-pair (i,i), whose other 2 entries are already forced
+      in by the always-include-the-diagonal rule above), so a plain
+      per-entry union already comes out block-complete with no special
+      handling needed here.
+
+    A short-range neighbor-shell v is overwhelmingly zero -- measured on a
+    98-site/196-orbital system, 0.02%-0.34% nonzero per off-diagonal
+    direction key -- so the result is normally a tiny fraction of the full
+    n^2 grid; see dmtk.fulldm.full_dm_batch_d_sparse and
+    densitymatrix.full_dm_accumulate_sparse for what computing only these
+    entries buys over the dense (n,n)@(n,n) per-direction matmul."""
+    all_dirs = set(keys)
+    for v in vlist:
+        if v is None: continue
+        for d in v:
+            all_dirs.add(d)
+            all_dirs.add((-d[0], -d[1], -d[2]))
+    masks = {d: np.zeros((n, n), dtype=bool) for d in all_dirs}
+    for v in vlist:
+        if v is None: continue
+        for d, m in v.items():
+            nz = (m != 0)
+            masks[d] |= nz               # own-direction uses (get_dc_energy, rotation input)
+            d2 = (-d[0], -d[1], -d[2])
+            masks[d2] |= nz.T            # cross-term uses dm[d2][j,i] for v[d][i,j] != 0
+    masks[(0, 0, 0)] |= np.kron(np.eye(n // 2, dtype=bool), np.ones((2, 2), dtype=bool))
+    pairs = dict()
+    for d, mask in masks.items():
+        rows, cols = np.nonzero(mask)
+        pairs[d] = (rows.astype(np.int64), cols.astype(np.int64))
+    return pairs
+
+
 def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         maxerror, maxite, T, verbose, constrains, vd=None):
     """Shared SCF core for Jinteraction/VJinteraction: decouples the
@@ -456,6 +524,27 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             Rx = build_rotation_matrix(n_orb, **_AXIS_ROTATION["x"]); Rxd = Rx.conj().T
         if vy_active:
             Ry = build_rotation_matrix(n_orb, **_AXIS_ROTATION["y"]); Ryd = Ry.conj().T
+
+    # sparse density-matrix path: only compute the (row,col) entries that
+    # normal_term_ii/jj/ij/ji actually read, instead of the full (n,n)
+    # matrix per direction (see _build_sparse_pairs/full_dm_accumulate_sparse).
+    # has_eh=False only: vd's Nambu-basis interaction matrix lives in the
+    # reordered Nambu convention (sctk/reorder.py), not the plain
+    # spin-orbital one _build_sparse_pairs assumes, so the Nambu case keeps
+    # the existing dense get_dm call below rather than risk misreading that
+    # reordering here -- a possible follow-up, not attempted in this pass.
+    use_sparse_dm = not has_eh
+    if use_sparse_dm:
+        n_dm = vz[(0, 0, 0)].shape[0]
+        sparse_pairs = _build_sparse_pairs(
+                [vz, vx, vy] + ([vd] if vd is not None else []), v_dirs, n_dm)
+
+    def _get_dm(h):
+        if use_sparse_dm:
+            from ..densitymatrix import full_dm_accumulate_sparse
+            delta = T if T != 0. else 1e-15 # see densitymatrix.full_dm's own T==0 guard
+            return full_dm_accumulate_sparse(h, sparse_pairs, nk=nk, delta=delta)
+        return get_dm(h, v_dirs, nk=nk, T=T, integration="ed")
 
     def _rot_dict(dd, R, Rd):
         """Rotate a dict of Hamiltonian-like (hopping/mean-field) matrices:
@@ -545,7 +634,7 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         hop = update_hamiltonian(hop0, mf)
         set_hoppings(h, hop)
         h = callback_h(h)
-        dm_lab = get_dm(h, v_dirs, nk=nk, T=T, integration="ed")
+        dm_lab = _get_dm(h)
         mfnew = compute_mf(dm_lab)
         if callback_mf is not None: mfnew = callback_mf(mfnew)
         scf = SCF()

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -720,6 +720,22 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             break
         ite += 1
 
+    if use_sparse_dm:
+        # scf.dm is a public field (Vinteraction/SzSz/SxSx/SySy's SCF
+        # objects always expose a fully dense one, via densitydensity.py's
+        # own get_dm), but the sparse path above only ever populated the
+        # (row,col) entries the SCF loop itself needed (see
+        # _build_sparse_pairs/full_dm_accumulate_sparse) -- leaving the
+        # rest silently at zero would corrupt any external use of scf.dm
+        # beyond the mean field itself (custom correlators, occupation
+        # diagnostics, symmetry checks). Recompute it fully dense exactly
+        # once here, for the converged (or not-converged-but-returned)
+        # Hamiltonian only -- not once per SCF iteration -- reusing the
+        # same dense get_dm the has_eh=True path below already relies on,
+        # so this is one extra diagonalization for the whole call, not a
+        # per-iteration cost.
+        scf.dm = get_dm(scf.hamiltonian, v_dirs, nk=nk, T=T, integration="ed")
+
     # total energy: sum of occupied energies plus the double-counting
     # correction for each of the three (independently-rotated) exchange
     # channels, plus vd's (if any) -- all electron-sector only. get_dc_energy

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -409,9 +409,12 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     vx/vy are skipped entirely (no rotation, no get_mf_normal/get_dc_energy
     call) when they are identically zero -- e.g. VJinteraction's pure
     density-density case (J1=J2=J3=J1x=J1y=0), where _build_v returns an
-    all-zero matrix for every key regardless of geometry. A zero
-    interaction contributes exactly zero mean field either way, so this
-    changes no result, only the cost of computing it -- see _channel_is_zero."""
+    all-zero matrix for every key regardless of geometry. vz and vd (when
+    given) get the same treatment: vz can be identically zero for a Nambu
+    VJinteraction call with only Jx/Jy set (J1=J2=J3=J1z=0), and vd for one
+    with only J's and no V/U. A zero interaction contributes exactly zero
+    mean field either way, so this changes no result, only the cost of
+    computing it -- see _channel_is_zero."""
     from .densitydensity import (get_dm, get_mf_normal, get_mf, mix_mf,
             diff_mf, update_hamiltonian, set_hoppings, hamiltonian2dict,
             get_dc_energy, SCF)
@@ -438,6 +441,8 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     # channel -- see this function's docstring.
     vx_active = not _channel_is_zero(vx)
     vy_active = not _channel_is_zero(vy)
+    vz_active = not _channel_is_zero(vz)
+    vd_active = vd is not None and not _channel_is_zero(vd)
     Rx = Ry = Rxd = Ryd = None
     if vx_active or vy_active:
         from ..rotate_spin import build_rotation_matrix
@@ -515,7 +520,12 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
 
     def compute_mf(dm_lab):
         dme_lab = electron_sector(dm_lab) # exchange channels: normal sector only
-        mf = get_mf_normal(vz, dme_lab)
+        if vz_active:
+            mf = get_mf_normal(vz, dme_lab)
+        else: # vz identically zero -- skip the O(n^2) pass, same reasoning
+              # as vx_active/vy_active (see _channel_is_zero)
+            zero = dme_lab[(0, 0, 0)]*0.0
+            mf = {d: zero.copy() for d in vz}
         if vx_active:
             dm_x = _rot_dm(dme_lab, Rx, Rxd) # dm needs the conjugated rotation
             mf_x = _rot_dict(get_mf_normal(vx, dm_x), Rxd, Rx) # mf does not
@@ -525,7 +535,7 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             mf_y = _rot_dict(get_mf_normal(vy, dm_y), Ryd, Ry)
             mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
         mf = embed_normal(mf)
-        if vd is not None: # density-density: full normal+anomalous treatment
+        if vd_active: # density-density: full normal+anomalous treatment
             mf_d = get_mf(vd, dm_lab, has_eh=has_eh)
             mf = (MultiHopping(mf) + MultiHopping(mf_d)).get_dict()
         return mf
@@ -607,14 +617,15 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     if mu is None:
         etot += h.fermi*h.intra.shape[0]*filling
     dme = electron_sector(scf.dm)
-    etot += get_dc_energy(vz, dme)
+    if vz_active:
+        etot += get_dc_energy(vz, dme)
     if vx_active:
         dm_x = _rot_dm(dme, Rx, Rxd) # dm needs the conjugated rotation, see compute_mf
         etot += get_dc_energy(vx, dm_x)
     if vy_active:
         dm_y = _rot_dm(dme, Ry, Ryd)
         etot += get_dc_energy(vy, dm_y)
-    if vd is not None:
+    if vd_active:
         etot += get_dc_energy(vd, dme)
     scf.total_energy = etot.real
     return scf

--- a/src/pyqula/selfconsistency/spinspin.py
+++ b/src/pyqula/selfconsistency/spinspin.py
@@ -497,16 +497,18 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     # at the union, not just vz's keys
     v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy) |
             (set(vd) if vd is not None else set()))}
-    # the x/y rotations are fixed for the whole SCF loop, so build the
-    # (small, 2x2-block) rotation matrices once via build_rotation_matrix
-    # instead of paying a fresh matrix exponential on every one of the many
+    # the x/y rotations are fixed for the whole SCF loop, so build the small
+    # 2x2 spin rotation matrices once via build_rotation_matrix instead of
+    # paying a fresh matrix exponential on every one of the many
     # _rotate_dict/_rotate_dm calls compute_mf makes each iteration; the
     # backward rotation is just the forward matrix's dagger (R(-angle) =
-    # R(angle)^dagger), so only Rx/Ry need to be built. Sized from vz's own
-    # shape (always the plain spin-orbital size, never Nambu-doubled, even
-    # when h1 itself is BdG) rather than h1.intra.shape, since the exchange
-    # channels are always decoupled in the (electron-sector-sized) normal
-    # channel -- see this function's docstring.
+    # R(angle)^dagger), so only Rx/Ry need to be built.
+    # build_rotation_matrix(1,...) returns exactly the small 2x2 spin
+    # rotation with no reshaping needed (kron with a 1x1 identity is a
+    # no-op) -- the full (2n_orb)x(2n_orb) kron'd matrix this used to build
+    # is never actually needed: see _block_rotate for why applying it is an
+    # O(n_orb^2) per-site contraction with this small matrix, not an
+    # O(n_orb^3) dense matmul against the big one.
     vx_active = not _channel_is_zero(vx)
     vy_active = not _channel_is_zero(vy)
     vz_active = not _channel_is_zero(vz)
@@ -514,16 +516,15 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     Rx = Ry = Rxd = Ryd = None
     if vx_active or vy_active:
         from ..rotate_spin import build_rotation_matrix
-        n_orb = vz[(0, 0, 0)].shape[0]//2
         # daggers precomputed once here (rather than inside _rot_dict/_rot_dm,
         # which previously recomputed R.conj().T -- once for the forward
         # rotation, again explicitly at each of that channel's two call
         # sites in compute_mf/the total-energy tail -- on every one of the
         # maxite SCF iterations for a rotation that never changes)
         if vx_active:
-            Rx = build_rotation_matrix(n_orb, **_AXIS_ROTATION["x"]); Rxd = Rx.conj().T
+            Rx = build_rotation_matrix(1, **_AXIS_ROTATION["x"]); Rxd = Rx.conj().T
         if vy_active:
-            Ry = build_rotation_matrix(n_orb, **_AXIS_ROTATION["y"]); Ryd = Ry.conj().T
+            Ry = build_rotation_matrix(1, **_AXIS_ROTATION["y"]); Ryd = Ry.conj().T
 
     # sparse density-matrix path: only compute the (row,col) entries that
     # normal_term_ii/jj/ij/ji actually read, instead of the full (n,n)
@@ -546,14 +547,30 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             return full_dm_accumulate_sparse(h, sparse_pairs, nk=nk, delta=delta)
         return get_dm(h, v_dirs, nk=nk, T=T, integration="ed")
 
-    def _rot_dict(dd, R, Rd):
+    def _block_rotate(m, rot):
+        """rot @ m @ rot^dagger, applied to every site's own 2x2 spin
+        sub-block of an (n,n) matrix independently, instead of a dense
+        (n,n)@(n,n) matmul against the full R=kron(I_{n/2},rot) a global
+        spin rotation used to be built as: R is block-diagonal with n/2
+        IDENTICAL 2x2 blocks (rotate_spin.build_rotation_matrix), so it
+        never mixes different sites -- only the 2 spin components within
+        each one. Two small (n/2 * 4)-cost einsum contractions reproduce
+        the same result as R @ m @ R^dagger at O(n^2) instead of O(n^3)."""
+        n = m.shape[0]
+        n_orb = n//2
+        m4 = m.reshape(n_orb, 2, n_orb, 2)
+        out = np.einsum('ab,xbyc->xayc', rot, m4, optimize=True)
+        out = np.einsum('xayc,dc->xayd', out, rot.conj(), optimize=True)
+        return out.reshape(n, n)
+
+    def _rot_dict(dd, R):
         """Rotate a dict of Hamiltonian-like (hopping/mean-field) matrices:
         these live in the same convention as Hamiltonian.intra, for which
         R @ m @ R^dagger is the correct transformation (as used by
         Hamiltonian.global_spin_rotation, validated by SxSx/SySy)."""
-        return {k: R @ m @ Rd for (k, m) in dd.items()}
+        return {k: _block_rotate(m, R) for (k, m) in dd.items()}
 
-    def _rot_dm(dd, R, Rd):
+    def _rot_dm(dd, R):
         """Rotate a dict of *density matrices*, which need a different
         (conjugate-sandwiched) transformation than _rot_dict.
 
@@ -575,7 +592,7 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         Conjugating before and after the standard rotation corrects for it:
         if dm_stored = conj(dm_physical), then
         dm_stored' = conj(dm_physical') = conj(R @ conj(dm_stored) @ R^dagger)."""
-        return {k: np.conj(R @ np.conj(m) @ Rd) for (k, m) in dd.items()}
+        return {k: np.conj(_block_rotate(np.conj(m), R)) for (k, m) in dd.items()}
 
     callback_mf = _callback_mf_constrains(h1, constrains)
 
@@ -616,12 +633,12 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
             zero = dme_lab[(0, 0, 0)]*0.0
             mf = {d: zero.copy() for d in vz}
         if vx_active:
-            dm_x = _rot_dm(dme_lab, Rx, Rxd) # dm needs the conjugated rotation
-            mf_x = _rot_dict(get_mf_normal(vx, dm_x), Rxd, Rx) # mf does not
+            dm_x = _rot_dm(dme_lab, Rx) # dm needs the conjugated rotation
+            mf_x = _rot_dict(get_mf_normal(vx, dm_x), Rxd) # mf does not
             mf = (MultiHopping(mf) + MultiHopping(mf_x)).get_dict()
         if vy_active:
-            dm_y = _rot_dm(dme_lab, Ry, Ryd)
-            mf_y = _rot_dict(get_mf_normal(vy, dm_y), Ryd, Ry)
+            dm_y = _rot_dm(dme_lab, Ry)
+            mf_y = _rot_dict(get_mf_normal(vy, dm_y), Ryd)
             mf = (MultiHopping(mf) + MultiHopping(mf_y)).get_dict()
         mf = embed_normal(mf)
         if vd_active: # density-density: full normal+anomalous treatment
@@ -633,8 +650,22 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
         h = h1.copy()
         hop = update_hamiltonian(hop0, mf)
         set_hoppings(h, hop)
-        h = callback_h(h)
-        dm_lab = _get_dm(h)
+        if use_sparse_dm and mu is None:
+            # combined: diagonalize the unshifted h once, deriving both the
+            # Fermi energy and the density matrix from the same
+            # eigenvectors, instead of callback_h's get_fermi4filling
+            # paying for an independent diagonalization sweep first -- see
+            # densitymatrix.full_dm_accumulate_sparse_with_fermi's docstring
+            from ..densitymatrix import full_dm_accumulate_sparse_with_fermi
+            delta = T if T != 0. else 1e-15 # see densitymatrix.full_dm's own T==0 guard
+            dm_lab, fermi = full_dm_accumulate_sparse_with_fermi(
+                    h, sparse_pairs, filling, nk=nk, delta=delta)
+            h.fermi = fermi
+            h.shift_fermi(-fermi) # cheap (adds a constant to the diagonal);
+                                   # the eigenvectors above are unaffected by it
+        else:
+            h = callback_h(h)
+            dm_lab = _get_dm(h)
         mfnew = compute_mf(dm_lab)
         if callback_mf is not None: mfnew = callback_mf(mfnew)
         scf = SCF()
@@ -709,10 +740,10 @@ def _run_anisotropic_scf(h1, vx, vy, vz, mf, filling, mu, mix, nk,
     if vz_active:
         etot += get_dc_energy(vz, dme)
     if vx_active:
-        dm_x = _rot_dm(dme, Rx, Rxd) # dm needs the conjugated rotation, see compute_mf
+        dm_x = _rot_dm(dme, Rx) # dm needs the conjugated rotation, see compute_mf
         etot += get_dc_energy(vx, dm_x)
     if vy_active:
-        dm_y = _rot_dm(dme, Ry, Ryd)
+        dm_y = _rot_dm(dme, Ry)
         etot += get_dc_energy(vy, dm_y)
     if vd_active:
         etot += get_dc_energy(vd, dme)

--- a/src/pyqula/selfconsistency/superscf.py
+++ b/src/pyqula/selfconsistency/superscf.py
@@ -29,7 +29,7 @@ def anomalous_term_ij(v,dm):
 
 # this anomalous term enforces even superconductivity
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def anomalous_term_ij_jit(v,dm,out):
     ns = len(dm)//2 # number of spinless sites
     for i in range(ns): # loop over spinless sites
@@ -61,7 +61,7 @@ def enforce_eh_from_sector(d):
     return out # return
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def enforce_eh_from_sector_jit(d,o):
     """Given the ee sector, return the hh sector"""
     return np.conjugate(d.T) # hermitian conjugate
@@ -87,7 +87,7 @@ def enforce_eh_symmetry_anomalous_sector(d01):
 
 
 
-@jit(nopython=True)
+@jit(nopython=True,cache=True)
 def enforce_eh_symmetry_anomalous_jit(d01,d10,o01):
     """Enforce electron-hole symmetry"""
     ns = len(d01)//2 # number of spinless sites

--- a/tests/scf/test_vjinteraction_sparse_dm.py
+++ b/tests/scf/test_vjinteraction_sparse_dm.py
@@ -1,0 +1,122 @@
+import numpy as np
+
+from pyqula import geometry
+from pyqula import meanfield
+from pyqula.multihopping import MultiHopping
+from pyqula.selfconsistency import spinspin
+from pyqula.selfconsistency.densitydensity import get_dm
+from pyqula.densitymatrix import (full_dm_accumulate, full_dm_accumulate_sparse,
+        full_dm_accumulate_sparse_with_fermi)
+
+# Regression coverage for the sparse density-matrix machinery
+# (selfconsistency.spinspin._build_sparse_pairs, densitymatrix's
+# full_dm_accumulate_sparse/full_dm_accumulate_sparse_with_fermi,
+# dmtk.fulldm.full_dm_batch_d_sparse) introduced for VJinteraction/
+# Jinteraction. None of the small-geometry tests elsewhere in this file/
+# module are large enough for any direction's requested-pair count to
+# cross the dense_fraction*n^2 threshold, so those tests always exercise
+# the dense-fallback branch only, never the actual sparse gather kernel --
+# these tests use a large enough system (98-site honeycomb supercell, 196
+# orbitals) that both branches are genuinely exercised, confirmed by
+# asserting on the pair counts directly rather than just trusting it.
+
+DENSE_FRACTION = 0.01
+
+
+def _build_vj_matrices(g):
+    h0 = g.get_hamiltonian(has_spin=True)
+    h1 = h0.get_multicell().get_dense()
+    nd = h1.geometry.neighbor_distances()
+    vz = spinspin._build_v(h1, -0.3, 0.1, 0.0, None, nd=nd)
+    vd = spinspin._build_density_v(h1, 0.3, 0.0, 0.0, 1.0, None, nd=nd)
+    vx = spinspin._build_v(h1, 0.05, 0.1, 0.0, None, nd=nd)
+    vy = spinspin._build_v(h1, 0.05, 0.1, 0.0, None, nd=nd)
+    vz = (MultiHopping(vz) + MultiHopping(vd)).get_dict()
+    v_dirs = {d: None for d in (set(vz) | set(vx) | set(vy))}
+    n = vz[(0, 0, 0)].shape[0]
+    pairs = spinspin._build_sparse_pairs([vz, vx, vy], v_dirs, n)
+    return h1, v_dirs, pairs, n
+
+
+def test_sparsity_thresholds_actually_exercise_both_branches():
+    """Sanity check for the tests below: on a 98-site/196-orbital system
+    with several active channels, some directions must fall under the
+    dense_fraction threshold (sparse kernel) and at least one must fall
+    over it (dense fallback) -- otherwise the tests further down would
+    silently only cover one branch, exactly the gap this file exists to
+    close."""
+    g = geometry.honeycomb_lattice().get_supercell(7)
+    _, _, pairs, n = _build_vj_matrices(g)
+    threshold = DENSE_FRACTION * n * n
+    npairs = {d: len(rows) for d, (rows, cols) in pairs.items()}
+    assert any(0 < c <= threshold for c in npairs.values()), npairs
+    assert any(c > threshold for c in npairs.values()), npairs
+
+
+def test_sparse_density_matrix_matches_dense_at_requested_positions():
+    """full_dm_accumulate_sparse (used for every SCF iteration) must agree
+    with the plain dense full_dm_accumulate at every position it actually
+    populates, for both the genuinely-sparse and the dense-fallback
+    directions."""
+    g = geometry.honeycomb_lattice().get_supercell(7)
+    h1, v_dirs, pairs, n = _build_vj_matrices(g)
+    nk = 4
+    dense = full_dm_accumulate(h1, ds=list(v_dirs), nk=nk, delta=1e-6)
+    sparse = full_dm_accumulate_sparse(h1, pairs, nk=nk, delta=1e-6)
+    for d in v_dirs:
+        rows, cols = pairs[d]
+        if len(rows) == 0:
+            continue
+        diff = np.max(np.abs(dense[d][rows, cols] - sparse[d][rows, cols]))
+        assert diff < 1e-9, (d, diff)
+
+
+def test_sparse_fermi_dedup_matches_two_diagonalization_reference():
+    """full_dm_accumulate_sparse_with_fermi (diagonalizes once) must match
+    the old get_fermi4filling + full_dm_accumulate_sparse sequence
+    (diagonalizes twice) to numerical precision, in both its normal
+    (hold-the-whole-mesh) mode and its max_memory_gb fallback mode."""
+    g = geometry.honeycomb_lattice().get_supercell(7)
+    h1, v_dirs, pairs, n = _build_vj_matrices(g)
+    filling, nk = 0.3, 4
+
+    fermi_ref = h1.get_fermi4filling(filling, nk=nk)
+    h_shifted = h1.copy()
+    h_shifted.shift_fermi(-fermi_ref)
+    dm_ref = full_dm_accumulate_sparse(h_shifted, pairs, nk=nk, delta=1e-6)
+
+    dm_combined, fermi_combined = full_dm_accumulate_sparse_with_fermi(
+            h1, pairs, filling, nk=nk, delta=1e-6)
+    dm_fallback, fermi_fallback = full_dm_accumulate_sparse_with_fermi(
+            h1, pairs, filling, nk=nk, delta=1e-6, max_memory_gb=1e-12)
+
+    assert abs(fermi_ref - fermi_combined) < 1e-9
+    assert abs(fermi_ref - fermi_fallback) < 1e-9
+    for d in v_dirs:
+        assert np.max(np.abs(dm_ref[d] - dm_combined[d])) < 1e-8, d
+        assert np.max(np.abs(dm_ref[d] - dm_fallback[d])) < 1e-8, d
+
+
+def test_vjinteraction_scf_dm_is_a_complete_density_matrix():
+    """scf.dm is a public field (Vinteraction/SzSz/SxSx/SySy's SCF objects
+    always expose a fully dense one); VJinteraction/Jinteraction's must be
+    too, even though the SCF loop internally only ever populates the
+    sparse subset it needs for its own use. Uses a fixed, small maxite
+    (not full convergence) purely to keep this fast -- the point is
+    checking the shape/completeness of the returned dm, not physical
+    convergence, which is already covered elsewhere."""
+    g = geometry.honeycomb_lattice().get_supercell(7)
+    h = g.get_hamiltonian(has_spin=True)
+    scf = meanfield.VJinteraction(h, V1=0.3, U=1.0, J1=-0.3, J2=0.1,
+            J1x=0.05, J1y=0.05, mf="ferroZ", nk=4, maxerror=1e-6, mix=0.3,
+            maxite=3, filling=0.3, verbose=0)
+
+    _, v_dirs, _, n = _build_vj_matrices(g)
+    dm_ref = get_dm(scf.hamiltonian, v_dirs, nk=4, T=1e-7, integration="ed")
+
+    for d in v_dirs:
+        assert np.max(np.abs(scf.dm[d] - dm_ref[d])) < 1e-8, d
+    nnz_scf = sum(np.count_nonzero(np.abs(scf.dm[d]) > 1e-14) for d in v_dirs)
+    nnz_ref = sum(np.count_nonzero(np.abs(dm_ref[d]) > 1e-14) for d in v_dirs)
+    # not just the handful of entries the sparse SCF loop itself needed
+    assert nnz_scf > 0.5 * nnz_ref, (nnz_scf, nnz_ref)


### PR DESCRIPTION
## Summary

Three rounds of measured speedups to VJinteraction/Jinteraction's shared SCF core (`selfconsistency/spinspin.py`'s `_run_anisotropic_scf`).

**Tier 1** (98-site benchmark):
- `cache=True` on the numba jit functions on the hot path, eliminating the ~10s one-time JIT recompilation tax paid on every fresh Python process. Fresh-process VJinteraction startup: ~15.6s → ~3.5s once the on-disk cache is warm.
- Extends the existing `_channel_is_zero` skip (previously only vx/vy) to vz/vd too.

**Tier 2** (98-site benchmark):
- A sparse density-matrix path for the normal-state case: only the `(row,col)` entries actually read downstream are computed per bond-direction key, instead of a full dense `(n,n)` matrix via a `(n,n)@(n,n)` matmul — derived once from the interaction matrices' fixed sparsity pattern. Adaptively falls back to the dense matmul above ~1-2% nonzero, where the sparse (non-BLAS) kernel is actually slower.
- Found and fixed a real correctness bug along the way: rotating the x/y exchange channels' density matrix mixes a 2x2 spin block's diagonal and off-diagonal entries together, so an initial version that only safety-netted the pure-diagonal entries silently zeroed the x/y mean-field contribution.
- Nambu (superconducting) Hamiltonians are unchanged — the interaction matrix lives in the reordered Nambu convention this pass doesn't handle.
- Net effect on the 98-site system: per-iteration cost ~0.54s → ~0.38s (~30% faster).

**Tier 3** (288-site benchmark, to match the scale where this matters most):
- **Fermi-diagonalization dedup**: every SCF iteration was diagonalizing the Hamiltonian *twice* — once (eigenvalues only) to locate the Fermi level for the target filling, and once more, independently, to build the density matrix, on the same Hamiltonian shifted by that Fermi level. Since shifting a Hamiltonian by a constant doesn't change its eigenvectors, this now diagonalizes once, derives the Fermi energy from the pooled eigenvalues, and reuses the same eigenvectors (eigenvalues shifted trivially) to build the density matrix.
- **Block-diagonal spin rotation**: the x/y exchange channels' density-matrix rotation was a dense `(n,n)@(n,n)` matmul against a matrix that's provably block-diagonal (a global spin rotation only ever mixes the 2 spin components within one site's own 2x2 block, never different sites) — now two small per-site einsum contractions, O(n²) instead of O(n³).
- Both scoped to the normal-state (has_eh=False) case, consistent with Tier 2.
- Net effect on a 288-site honeycomb supercell (same worst-case V1/U/J1/J2/J1x/J1y config as prior tiers): per-iteration cost ~5.1s → ~1.9s, **~2.7x faster** — a much bigger relative win than at 98 sites, since diagonalization cost scales as O(n³) and increasingly dominates at larger sizes.

All three tiers are pure performance (plus the one Tier-2 bug fix) — no other change to the numerics. Optimization effort and benchmarking was focused on VJinteraction specifically (per user request), though the shared `_run_anisotropic_scf` core means Jinteraction benefits too and its tests must (and do) still pass.

## Test plan
- [x] `python -m pytest tests/scf` — 66 passed, run independently after each tier
- [x] Sub-step correctness checks for each tier: sparse vs. dense density-matrix computation, block-rotation vs. dense R@m@R†, and the Fermi/density-matrix combo vs. the old two-diagonalization sequence — all compared entry-by-entry against the reference implementation
- [x] Benchmarked before/after at each tier (98-site for Tiers 1-2, 288-site for Tier 3 — see summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAoiDzJuVjGZWgHRDU1GW